### PR TITLE
feat: implement OneClick, ApplePay, GooglePay endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@
 | payment/reverse   | yes                 |
 | payment/close     | yes                 |
 | payment/refund    | yes                 |
-| oneclick/echo     | no                  |
-| oneclick/init     | no                  |
-| oneclick/process  | no                  |
-| applepay/echo     | no                  |
-| applepay/init     | no                  |
-| applepay/process  | no                  |
-| googlepay/echo    | no                  |
-| googlepay/init    | no                  |
-| googlepay/process | no                  |
+| oneclick/echo     | yes                 |
+| oneclick/init     | yes                 |
+| oneclick/process  | yes                 |
+| applepay/echo     | yes                 |
+| applepay/init     | yes                 |
+| applepay/process  | yes                 |
+| googlepay/echo    | yes                 |
+| googlepay/init    | yes                 |
+| googlepay/process | yes                 |
 
   [test status image]: https://github.com/connorhu/khvpos/actions/workflows/tests.yml/badge.svg?branch=master
   [test status]: https://github.com/connorhu/khvpos/actions/workflows/tests.yml

--- a/src/Models/Fingerprint.php
+++ b/src/Models/Fingerprint.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Models;
+
+class Fingerprint
+{
+	/**
+	 * @var array<string, mixed>|null
+	 */
+	private ?array $browserData = null;
+
+	/**
+	 * @var array<string, mixed>|null
+	 */
+	private ?array $sdkData = null;
+
+	/**
+	 * @return array<string, mixed>|null
+	 */
+	public function getBrowserData(): ?array
+	{
+		return $this->browserData;
+	}
+
+	/**
+	 * @param array<string, mixed>|null $browserData
+	 */
+	public function setBrowserData(?array $browserData): void
+	{
+		$this->browserData = $browserData;
+	}
+
+	/**
+	 * @return array<string, mixed>|null
+	 */
+	public function getSdkData(): ?array
+	{
+		return $this->sdkData;
+	}
+
+	/**
+	 * @param array<string, mixed>|null $sdkData
+	 */
+	public function setSdkData(?array $sdkData): void
+	{
+		$this->sdkData = $sdkData;
+	}
+}

--- a/src/Models/Fingerprint.php
+++ b/src/Models/Fingerprint.php
@@ -25,11 +25,9 @@ class Fingerprint
 	/**
 	 * @param array<string, mixed>|null $browserData
 	 */
-	public function setBrowserData(?array $browserData): self
+	public function setBrowserData(?array $browserData): void
 	{
 		$this->browserData = $browserData;
-
-		return $this;
 	}
 
 	/**
@@ -43,10 +41,8 @@ class Fingerprint
 	/**
 	 * @param array<string, mixed>|null $sdkData
 	 */
-	public function setSdkData(?array $sdkData): self
+	public function setSdkData(?array $sdkData): void
 	{
 		$this->sdkData = $sdkData;
-
-		return $this;
 	}
 }

--- a/src/Models/Fingerprint.php
+++ b/src/Models/Fingerprint.php
@@ -25,9 +25,11 @@ class Fingerprint
 	/**
 	 * @param array<string, mixed>|null $browserData
 	 */
-	public function setBrowserData(?array $browserData): void
+	public function setBrowserData(?array $browserData): self
 	{
 		$this->browserData = $browserData;
+
+		return $this;
 	}
 
 	/**
@@ -41,8 +43,10 @@ class Fingerprint
 	/**
 	 * @param array<string, mixed>|null $sdkData
 	 */
-	public function setSdkData(?array $sdkData): void
+	public function setSdkData(?array $sdkData): self
 	{
 		$this->sdkData = $sdkData;
+
+		return $this;
 	}
 }

--- a/src/Models/InitParams.php
+++ b/src/Models/InitParams.php
@@ -23,29 +23,23 @@ class InitParams
 
 	public function getMerchantIdentifier(): ?string { return $this->merchantIdentifier; }
 
-	public function setMerchantIdentifier(?string $merchantIdentifier): self
+	public function setMerchantIdentifier(?string $merchantIdentifier): void
 	{
 		$this->merchantIdentifier = $merchantIdentifier;
-
-		return $this;
 	}
 
 	public function getMerchantName(): ?string { return $this->merchantName; }
 
-	public function setMerchantName(?string $merchantName): self
+	public function setMerchantName(?string $merchantName): void
 	{
 		$this->merchantName = $merchantName;
-
-		return $this;
 	}
 
 	public function getMerchantCountry(): ?string { return $this->merchantCountry; }
 
-	public function setMerchantCountry(?string $merchantCountry): self
+	public function setMerchantCountry(?string $merchantCountry): void
 	{
 		$this->merchantCountry = $merchantCountry;
-
-		return $this;
 	}
 
 	/**
@@ -56,10 +50,8 @@ class InitParams
 	/**
 	 * @param list<string>|null $supportedNetworks
 	 */
-	public function setSupportedNetworks(?array $supportedNetworks): self
+	public function setSupportedNetworks(?array $supportedNetworks): void
 	{
 		$this->supportedNetworks = $supportedNetworks;
-
-		return $this;
 	}
 }

--- a/src/Models/InitParams.php
+++ b/src/Models/InitParams.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Models;
+
+use Symfony\Component\Serializer\Annotation\SerializedName;
+
+class InitParams
+{
+	#[SerializedName(serializedName: 'merchantIdentifier')]
+	private ?string $merchantIdentifier = null;
+
+	#[SerializedName(serializedName: 'merchantName')]
+	private ?string $merchantName = null;
+
+	#[SerializedName(serializedName: 'merchantCountry')]
+	private ?string $merchantCountry = null;
+
+	/**
+	 * @var list<string>|null
+	 */
+	#[SerializedName(serializedName: 'supportedNetworks')]
+	private ?array $supportedNetworks = null;
+
+	public function getMerchantIdentifier(): ?string { return $this->merchantIdentifier; }
+	public function setMerchantIdentifier(?string $merchantIdentifier): void { $this->merchantIdentifier = $merchantIdentifier; }
+
+	public function getMerchantName(): ?string { return $this->merchantName; }
+	public function setMerchantName(?string $merchantName): void { $this->merchantName = $merchantName; }
+
+	public function getMerchantCountry(): ?string { return $this->merchantCountry; }
+	public function setMerchantCountry(?string $merchantCountry): void { $this->merchantCountry = $merchantCountry; }
+
+	/**
+	 * @return list<string>|null
+	 */
+	public function getSupportedNetworks(): ?array { return $this->supportedNetworks; }
+
+	/**
+	 * @param list<string>|null $supportedNetworks
+	 */
+	public function setSupportedNetworks(?array $supportedNetworks): void { $this->supportedNetworks = $supportedNetworks; }
+}

--- a/src/Models/InitParams.php
+++ b/src/Models/InitParams.php
@@ -22,13 +22,31 @@ class InitParams
 	private ?array $supportedNetworks = null;
 
 	public function getMerchantIdentifier(): ?string { return $this->merchantIdentifier; }
-	public function setMerchantIdentifier(?string $merchantIdentifier): void { $this->merchantIdentifier = $merchantIdentifier; }
+
+	public function setMerchantIdentifier(?string $merchantIdentifier): self
+	{
+		$this->merchantIdentifier = $merchantIdentifier;
+
+		return $this;
+	}
 
 	public function getMerchantName(): ?string { return $this->merchantName; }
-	public function setMerchantName(?string $merchantName): void { $this->merchantName = $merchantName; }
+
+	public function setMerchantName(?string $merchantName): self
+	{
+		$this->merchantName = $merchantName;
+
+		return $this;
+	}
 
 	public function getMerchantCountry(): ?string { return $this->merchantCountry; }
-	public function setMerchantCountry(?string $merchantCountry): void { $this->merchantCountry = $merchantCountry; }
+
+	public function setMerchantCountry(?string $merchantCountry): self
+	{
+		$this->merchantCountry = $merchantCountry;
+
+		return $this;
+	}
 
 	/**
 	 * @return list<string>|null
@@ -38,5 +56,10 @@ class InitParams
 	/**
 	 * @param list<string>|null $supportedNetworks
 	 */
-	public function setSupportedNetworks(?array $supportedNetworks): void { $this->supportedNetworks = $supportedNetworks; }
+	public function setSupportedNetworks(?array $supportedNetworks): self
+	{
+		$this->supportedNetworks = $supportedNetworks;
+
+		return $this;
+	}
 }

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -231,10 +231,9 @@ class Order
     /**
      * @param int|null $trxUsage
      */
-    public function setTrxUsage(?int $trxUsage): static
+    public function setTrxUsage(?int $trxUsage): void
     {
         $this->trxUsage = $trxUsage;
-        return $this;
     }
 
     /**

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -37,6 +37,9 @@ class Order
 
     private ?bool $reorder = null;
 
+    #[SerializedName(serializedName: 'trxUsage')]
+    private ?int $trxUsage = null;
+
     /** @var array<int, GiftCard> */
     #[SerializedName(serializedName: 'giftcards')]
     private array $giftCards = [];
@@ -215,6 +218,23 @@ class Order
     public function setReorder(?bool $reorder): void
     {
         $this->reorder = $reorder;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getTrxUsage(): ?int
+    {
+        return $this->trxUsage;
+    }
+
+    /**
+     * @param int|null $trxUsage
+     */
+    public function setTrxUsage(?int $trxUsage): static
+    {
+        $this->trxUsage = $trxUsage;
+        return $this;
     }
 
     /**

--- a/src/Requests/ApplePayEchoRequest.php
+++ b/src/Requests/ApplePayEchoRequest.php
@@ -1,41 +1,51 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace KHTools\VPos\Requests;
 
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Normalizers\NormalizerResultOrderingHelper;
 use KHTools\VPos\Requests\Traits\MerchantTrait;
+use KHTools\VPos\Responses\ApplePayEchoResponse;
 use Symfony\Component\Serializer\Annotation\Ignore;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
 class ApplePayEchoRequest implements RequestInterface
 {
-    use MerchantTrait;
+	use MerchantTrait;
 
-    private ?string $clientIp = null;
+	#[Ignore]
+	public function getRequestMethod(): string
+	{
+		return 'POST';
+	}
 
-    private ?string $payload = null;
+	#[Ignore]
+	public function getEndpointPath(): string
+	{
+		return '/applepay/echo';
+	}
 
-    private bool $sdkUsed = false;
+	#[Ignore]
+	public function getResponseClass(): string
+	{
+		return ApplePayEchoResponse::class;
+	}
 
-    #[Ignore]
-    public function getRequestMethod(): string
-    {
-        return 'POST';
-    }
-
-    #[Ignore]
-    public function getEndpointPath(): string
-    {
-        return '/applepay/echo';
-    }
-
-    #[Ignore]
-    public function getResponseClass(): string
-    {
-        throw new \LogicException('Not yet implemented');
-    }
-
-    #[Ignore]
-    public function getNormalizationContext(): array
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	#[Ignore]
+	public function getNormalizationContext(): array
+	{
+		return [
+			AbstractNormalizer::CALLBACKS => [
+				'merchant' => function (Merchant $value): string {
+					return $value->merchantId;
+				},
+			],
+			AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+			NormalizerResultOrderingHelper::ORDER => [
+				'merchantId',
+				'dttm',
+			],
+		];
+	}
 }

--- a/src/Requests/ApplePayInitRequest.php
+++ b/src/Requests/ApplePayInitRequest.php
@@ -1,35 +1,134 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace KHTools\VPos\Requests;
 
+use KHTools\VPos\Models\Customer;
+use KHTools\VPos\Models\Enums\Currency;
+use KHTools\VPos\Models\Enums\HttpMethod;
+use KHTools\VPos\Models\Enums\Language;
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Models\Order;
+use KHTools\VPos\Normalizers\NormalizerResultOrderingHelper;
 use KHTools\VPos\Requests\Traits\MerchantTrait;
+use KHTools\VPos\Responses\ApplePayInitResponse;
 use Symfony\Component\Serializer\Annotation\Ignore;
+use Symfony\Component\Serializer\Annotation\SerializedName;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 
 class ApplePayInitRequest implements RequestInterface
 {
-    use MerchantTrait;
+	use MerchantTrait;
 
-    #[Ignore]
-    public function getRequestMethod(): string
-    {
-        return 'POST';
-    }
+	#[SerializedName(serializedName: 'orderNo')]
+	private string $orderNumber;
 
-    #[Ignore]
-    public function getEndpointPath(): string
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	private int $totalAmount;
 
-    #[Ignore]
-    public function getResponseClass(): string
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	private Currency $currency;
 
-    #[Ignore]
-    public function getNormalizationContext(): array
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	private string $payload;
+
+	private string $returnUrl;
+
+	private HttpMethod $returnMethod;
+
+	private ?string $clientIp = null;
+
+	private ?bool $closePayment = null;
+
+	private ?Customer $customer = null;
+
+	private ?Order $order = null;
+
+	private ?bool $sdkUsed = null;
+
+	private ?string $merchantData = null;
+
+	private ?Language $language = null;
+
+	#[SerializedName(serializedName: 'ttlSec')]
+	private ?int $ttl = null;
+
+	#[Ignore]
+	public function getRequestMethod(): string { return 'POST'; }
+
+	#[Ignore]
+	public function getEndpointPath(): string { return '/applepay/init'; }
+
+	#[Ignore]
+	public function getResponseClass(): string { return ApplePayInitResponse::class; }
+
+	#[Ignore]
+	public function getNormalizationContext(): array
+	{
+		return [
+			AbstractNormalizer::CALLBACKS => [
+				'merchant' => function (Merchant $value): string {
+					return $value->merchantId;
+				},
+				'totalAmount' => function (int $value, ApplePayInitRequest $object): int {
+					return $object->getRawTotalAmount();
+				},
+			],
+			AbstractNormalizer::IGNORED_ATTRIBUTES => ['rawTotalAmount'],
+			AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+			DateTimeNormalizer::FORMAT_KEY => 'c',
+			NormalizerResultOrderingHelper::ORDER => [
+				'merchantId', 'orderNo', 'dttm', 'clientIp',
+				'totalAmount', 'currency', 'closePayment', 'payload',
+				'returnUrl', 'returnMethod', 'customer', 'order',
+				'sdkUsed', 'merchantData', 'language', 'ttlSec',
+			],
+		];
+	}
+
+	public function getTotalAmount(): float { return $this->totalAmount / 100; }
+
+	public function getRawTotalAmount(): int { return $this->totalAmount; }
+
+	public function setTotalAmount(float $totalAmount): void
+	{
+		$this->totalAmount = (int) \bcmul(number_format($totalAmount, 2, '.', ''), '100');
+	}
+
+	public function getOrderNumber(): string { return $this->orderNumber; }
+	public function setOrderNumber(string $orderNumber): void { $this->orderNumber = $orderNumber; }
+
+	public function getCurrency(): Currency { return $this->currency; }
+	public function setCurrency(Currency $currency): void { $this->currency = $currency; }
+
+	public function getPayload(): string { return $this->payload; }
+	public function setPayload(string $payload): void { $this->payload = $payload; }
+
+	public function getReturnUrl(): string { return $this->returnUrl; }
+	public function setReturnUrl(string $returnUrl): void { $this->returnUrl = $returnUrl; }
+
+	public function getReturnMethod(): HttpMethod { return $this->returnMethod; }
+	public function setReturnMethod(HttpMethod $returnMethod): void { $this->returnMethod = $returnMethod; }
+
+	public function getClientIp(): ?string { return $this->clientIp; }
+	public function setClientIp(?string $clientIp): void { $this->clientIp = $clientIp; }
+
+	public function getClosePayment(): ?bool { return $this->closePayment; }
+	public function setClosePayment(?bool $closePayment): void { $this->closePayment = $closePayment; }
+
+	public function getCustomer(): ?Customer { return $this->customer; }
+	public function setCustomer(?Customer $customer): void { $this->customer = $customer; }
+
+	public function getOrder(): ?Order { return $this->order; }
+	public function setOrder(?Order $order): void { $this->order = $order; }
+
+	public function getSdkUsed(): ?bool { return $this->sdkUsed; }
+	public function setSdkUsed(?bool $sdkUsed): void { $this->sdkUsed = $sdkUsed; }
+
+	public function getMerchantData(): ?string { return $this->merchantData; }
+	public function setMerchantData(?string $merchantData): void { $this->merchantData = $merchantData; }
+
+	public function getLanguage(): ?Language { return $this->language; }
+	public function setLanguage(?Language $language): void { $this->language = $language; }
+
+	public function getTtl(): ?int { return $this->ttl; }
+	public function setTtl(?int $ttl): void { $this->ttl = $ttl; }
 }

--- a/src/Requests/ApplePayProcessRequest.php
+++ b/src/Requests/ApplePayProcessRequest.php
@@ -1,35 +1,49 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace KHTools\VPos\Requests;
 
+use KHTools\VPos\Models\Fingerprint;
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Normalizers\NormalizerResultOrderingHelper;
 use KHTools\VPos\Requests\Traits\MerchantTrait;
+use KHTools\VPos\Requests\Traits\PaymentIdTrait;
+use KHTools\VPos\Responses\ApplePayProcessResponse;
 use Symfony\Component\Serializer\Annotation\Ignore;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
 class ApplePayProcessRequest implements RequestInterface
 {
-    use MerchantTrait;
+	use MerchantTrait;
+	use PaymentIdTrait;
 
-    #[Ignore]
-    public function getRequestMethod(): string
-    {
-        return 'POST';
-    }
+	private ?Fingerprint $fingerprint = null;
 
-    #[Ignore]
-    public function getEndpointPath(): string
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	#[Ignore]
+	public function getRequestMethod(): string { return 'POST'; }
 
-    #[Ignore]
-    public function getResponseClass(): string
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	#[Ignore]
+	public function getEndpointPath(): string { return '/applepay/process'; }
 
-    #[Ignore]
-    public function getNormalizationContext(): array
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	#[Ignore]
+	public function getResponseClass(): string { return ApplePayProcessResponse::class; }
+
+	#[Ignore]
+	public function getNormalizationContext(): array
+	{
+		return [
+			AbstractNormalizer::CALLBACKS => [
+				'merchant' => function (Merchant $value): string {
+					return $value->merchantId;
+				},
+			],
+			AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+			NormalizerResultOrderingHelper::ORDER => [
+				'merchantId', 'payId', 'dttm', 'fingerprint',
+			],
+		];
+	}
+
+	public function getFingerprint(): ?Fingerprint { return $this->fingerprint; }
+	public function setFingerprint(?Fingerprint $fingerprint): void { $this->fingerprint = $fingerprint; }
 }

--- a/src/Requests/GooglePayEchoRequest.php
+++ b/src/Requests/GooglePayEchoRequest.php
@@ -1,35 +1,51 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace KHTools\VPos\Requests;
 
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Normalizers\NormalizerResultOrderingHelper;
 use KHTools\VPos\Requests\Traits\MerchantTrait;
+use KHTools\VPos\Responses\GooglePayEchoResponse;
 use Symfony\Component\Serializer\Annotation\Ignore;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
 class GooglePayEchoRequest implements RequestInterface
 {
-    use MerchantTrait;
+	use MerchantTrait;
 
-    #[Ignore]
-    public function getRequestMethod(): string
-    {
-        return 'POST';
-    }
+	#[Ignore]
+	public function getRequestMethod(): string
+	{
+		return 'POST';
+	}
 
-    #[Ignore]
-    public function getEndpointPath(): string
-    {
-        return '/googlepay/echo';
-    }
+	#[Ignore]
+	public function getEndpointPath(): string
+	{
+		return '/googlepay/echo';
+	}
 
-    #[Ignore]
-    public function getResponseClass(): string
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	#[Ignore]
+	public function getResponseClass(): string
+	{
+		return GooglePayEchoResponse::class;
+	}
 
-    #[Ignore]
-    public function getNormalizationContext(): array
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	#[Ignore]
+	public function getNormalizationContext(): array
+	{
+		return [
+			AbstractNormalizer::CALLBACKS => [
+				'merchant' => function (Merchant $value): string {
+					return $value->merchantId;
+				},
+			],
+			AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+			NormalizerResultOrderingHelper::ORDER => [
+				'merchantId',
+				'dttm',
+			],
+		];
+	}
 }

--- a/src/Requests/GooglePayInitRequest.php
+++ b/src/Requests/GooglePayInitRequest.php
@@ -1,35 +1,134 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace KHTools\VPos\Requests;
 
+use KHTools\VPos\Models\Customer;
+use KHTools\VPos\Models\Enums\Currency;
+use KHTools\VPos\Models\Enums\HttpMethod;
+use KHTools\VPos\Models\Enums\Language;
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Models\Order;
+use KHTools\VPos\Normalizers\NormalizerResultOrderingHelper;
 use KHTools\VPos\Requests\Traits\MerchantTrait;
+use KHTools\VPos\Responses\GooglePayInitResponse;
 use Symfony\Component\Serializer\Annotation\Ignore;
+use Symfony\Component\Serializer\Annotation\SerializedName;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 
 class GooglePayInitRequest implements RequestInterface
 {
-    use MerchantTrait;
+	use MerchantTrait;
 
-    #[Ignore]
-    public function getRequestMethod(): string
-    {
-        return 'POST';
-    }
+	#[SerializedName(serializedName: 'orderNo')]
+	private string $orderNumber;
 
-    #[Ignore]
-    public function getEndpointPath(): string
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	private int $totalAmount;
 
-    #[Ignore]
-    public function getResponseClass(): string
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	private Currency $currency;
 
-    #[Ignore]
-    public function getNormalizationContext(): array
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	private string $payload;
+
+	private string $returnUrl;
+
+	private HttpMethod $returnMethod;
+
+	private ?string $clientIp = null;
+
+	private ?bool $closePayment = null;
+
+	private ?Customer $customer = null;
+
+	private ?Order $order = null;
+
+	private ?bool $sdkUsed = null;
+
+	private ?string $merchantData = null;
+
+	private ?Language $language = null;
+
+	#[SerializedName(serializedName: 'ttlSec')]
+	private ?int $ttl = null;
+
+	#[Ignore]
+	public function getRequestMethod(): string { return 'POST'; }
+
+	#[Ignore]
+	public function getEndpointPath(): string { return '/googlepay/init'; }
+
+	#[Ignore]
+	public function getResponseClass(): string { return GooglePayInitResponse::class; }
+
+	#[Ignore]
+	public function getNormalizationContext(): array
+	{
+		return [
+			AbstractNormalizer::CALLBACKS => [
+				'merchant' => function (Merchant $value): string {
+					return $value->merchantId;
+				},
+				'totalAmount' => function (int $value, GooglePayInitRequest $object): int {
+					return $object->getRawTotalAmount();
+				},
+			],
+			AbstractNormalizer::IGNORED_ATTRIBUTES => ['rawTotalAmount'],
+			AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+			DateTimeNormalizer::FORMAT_KEY => 'c',
+			NormalizerResultOrderingHelper::ORDER => [
+				'merchantId', 'orderNo', 'dttm', 'clientIp',
+				'totalAmount', 'currency', 'closePayment', 'payload',
+				'returnUrl', 'returnMethod', 'customer', 'order',
+				'sdkUsed', 'merchantData', 'language', 'ttlSec',
+			],
+		];
+	}
+
+	public function getTotalAmount(): float { return $this->totalAmount / 100; }
+
+	public function getRawTotalAmount(): int { return $this->totalAmount; }
+
+	public function setTotalAmount(float $totalAmount): void
+	{
+		$this->totalAmount = (int) \bcmul(number_format($totalAmount, 2, '.', ''), '100');
+	}
+
+	public function getOrderNumber(): string { return $this->orderNumber; }
+	public function setOrderNumber(string $orderNumber): void { $this->orderNumber = $orderNumber; }
+
+	public function getCurrency(): Currency { return $this->currency; }
+	public function setCurrency(Currency $currency): void { $this->currency = $currency; }
+
+	public function getPayload(): string { return $this->payload; }
+	public function setPayload(string $payload): void { $this->payload = $payload; }
+
+	public function getReturnUrl(): string { return $this->returnUrl; }
+	public function setReturnUrl(string $returnUrl): void { $this->returnUrl = $returnUrl; }
+
+	public function getReturnMethod(): HttpMethod { return $this->returnMethod; }
+	public function setReturnMethod(HttpMethod $returnMethod): void { $this->returnMethod = $returnMethod; }
+
+	public function getClientIp(): ?string { return $this->clientIp; }
+	public function setClientIp(?string $clientIp): void { $this->clientIp = $clientIp; }
+
+	public function getClosePayment(): ?bool { return $this->closePayment; }
+	public function setClosePayment(?bool $closePayment): void { $this->closePayment = $closePayment; }
+
+	public function getCustomer(): ?Customer { return $this->customer; }
+	public function setCustomer(?Customer $customer): void { $this->customer = $customer; }
+
+	public function getOrder(): ?Order { return $this->order; }
+	public function setOrder(?Order $order): void { $this->order = $order; }
+
+	public function getSdkUsed(): ?bool { return $this->sdkUsed; }
+	public function setSdkUsed(?bool $sdkUsed): void { $this->sdkUsed = $sdkUsed; }
+
+	public function getMerchantData(): ?string { return $this->merchantData; }
+	public function setMerchantData(?string $merchantData): void { $this->merchantData = $merchantData; }
+
+	public function getLanguage(): ?Language { return $this->language; }
+	public function setLanguage(?Language $language): void { $this->language = $language; }
+
+	public function getTtl(): ?int { return $this->ttl; }
+	public function setTtl(?int $ttl): void { $this->ttl = $ttl; }
 }

--- a/src/Requests/GooglePayProcessRequest.php
+++ b/src/Requests/GooglePayProcessRequest.php
@@ -1,35 +1,49 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace KHTools\VPos\Requests;
 
+use KHTools\VPos\Models\Fingerprint;
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Normalizers\NormalizerResultOrderingHelper;
 use KHTools\VPos\Requests\Traits\MerchantTrait;
+use KHTools\VPos\Requests\Traits\PaymentIdTrait;
+use KHTools\VPos\Responses\GooglePayProcessResponse;
 use Symfony\Component\Serializer\Annotation\Ignore;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
 class GooglePayProcessRequest implements RequestInterface
 {
-    use MerchantTrait;
+	use MerchantTrait;
+	use PaymentIdTrait;
 
-    #[Ignore]
-    public function getRequestMethod(): string
-    {
-        return 'POST';
-    }
+	private ?Fingerprint $fingerprint = null;
 
-    #[Ignore]
-    public function getEndpointPath(): string
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	#[Ignore]
+	public function getRequestMethod(): string { return 'POST'; }
 
-    #[Ignore]
-    public function getResponseClass(): string
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	#[Ignore]
+	public function getEndpointPath(): string { return '/googlepay/process'; }
 
-    #[Ignore]
-    public function getNormalizationContext(): array
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	#[Ignore]
+	public function getResponseClass(): string { return GooglePayProcessResponse::class; }
+
+	#[Ignore]
+	public function getNormalizationContext(): array
+	{
+		return [
+			AbstractNormalizer::CALLBACKS => [
+				'merchant' => function (Merchant $value): string {
+					return $value->merchantId;
+				},
+			],
+			AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+			NormalizerResultOrderingHelper::ORDER => [
+				'merchantId', 'payId', 'dttm', 'fingerprint',
+			],
+		];
+	}
+
+	public function getFingerprint(): ?Fingerprint { return $this->fingerprint; }
+	public function setFingerprint(?Fingerprint $fingerprint): void { $this->fingerprint = $fingerprint; }
 }

--- a/src/Requests/OneClickEchoRequest.php
+++ b/src/Requests/OneClickEchoRequest.php
@@ -2,54 +2,65 @@
 
 namespace KHTools\VPos\Requests;
 
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Normalizers\NormalizerResultOrderingHelper;
 use KHTools\VPos\Requests\Traits\MerchantTrait;
+use KHTools\VPos\Responses\OneClickEchoResponse;
 use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Annotation\SerializedName;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
 class OneClickEchoRequest implements RequestInterface
 {
-    use MerchantTrait;
+	use MerchantTrait;
 
-    #[SerializedName(serializedName: 'origPayId')]
-    private ?string $originalPaymentId = null;
+	#[SerializedName(serializedName: 'origPayId')]
+	private ?string $originalPaymentId = null;
 
-    #[Ignore]
-    public function getRequestMethod(): string
-    {
-        return 'POST';
-    }
+	#[Ignore]
+	public function getRequestMethod(): string
+	{
+		return 'POST';
+	}
 
-    #[Ignore]
-    public function getEndpointPath(): string
-    {
-        return '/oneclick/echo';
-    }
+	#[Ignore]
+	public function getEndpointPath(): string
+	{
+		return '/oneclick/echo';
+	}
 
-    #[Ignore]
-    public function getResponseClass(): string
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	#[Ignore]
+	public function getResponseClass(): string
+	{
+		return OneClickEchoResponse::class;
+	}
 
-    /**
-     * @return string|null
-     */
-    public function getOriginalPaymentId(): ?string
-    {
-        return $this->originalPaymentId;
-    }
+	#[Ignore]
+	public function getNormalizationContext(): array
+	{
+		return [
+			AbstractNormalizer::CALLBACKS => [
+				'merchant' => function (Merchant $value): string {
+					return $value->merchantId;
+				},
+			],
+			AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+			NormalizerResultOrderingHelper::ORDER => [
+				'merchantId',
+				'origPayId',
+				'dttm',
+			],
+		];
+	}
 
-    /**
-     * @param string|null $originalPaymentId
-     */
-    public function setOriginalPaymentId(?string $originalPaymentId): void
-    {
-        $this->originalPaymentId = $originalPaymentId;
-    }
+	public function getOriginalPaymentId(): ?string
+	{
+		return $this->originalPaymentId;
+	}
 
-    #[Ignore]
-    public function getNormalizationContext(): array
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	public function setOriginalPaymentId(?string $originalPaymentId): void
+	{
+		$this->originalPaymentId = $originalPaymentId;
+	}
 }

--- a/src/Requests/OneClickInitRequest.php
+++ b/src/Requests/OneClickInitRequest.php
@@ -1,35 +1,143 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace KHTools\VPos\Requests;
 
+use KHTools\VPos\Models\Customer;
+use KHTools\VPos\Models\Enums\Currency;
+use KHTools\VPos\Models\Enums\HttpMethod;
+use KHTools\VPos\Models\Enums\Language;
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Models\Order;
+use KHTools\VPos\Normalizers\NormalizerResultOrderingHelper;
 use KHTools\VPos\Requests\Traits\MerchantTrait;
+use KHTools\VPos\Responses\OneClickInitResponse;
 use Symfony\Component\Serializer\Annotation\Ignore;
+use Symfony\Component\Serializer\Annotation\SerializedName;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 
 class OneClickInitRequest implements RequestInterface
 {
-    use MerchantTrait;
+	use MerchantTrait;
 
-    #[Ignore]
-    public function getRequestMethod(): string
-    {
-        return 'POST';
-    }
+	#[SerializedName(serializedName: 'origPayId')]
+	private string $originalPaymentId;
 
-    #[Ignore]
-    public function getEndpointPath(): string
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	#[SerializedName(serializedName: 'orderNo')]
+	private string $orderNumber;
 
-    #[Ignore]
-    public function getResponseClass(): string
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	private string $returnUrl;
 
-    #[Ignore]
-    public function getNormalizationContext(): array
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	private HttpMethod $returnMethod;
+
+	private ?string $clientIp = null;
+
+	private ?int $totalAmount = null;
+
+	private ?Currency $currency = null;
+
+	private ?bool $closePayment = null;
+
+	private ?Customer $customer = null;
+
+	private ?Order $order = null;
+
+	private ?bool $clientInitiated = null;
+
+	private ?bool $sdkUsed = null;
+
+	private ?string $merchantData = null;
+
+	private ?Language $language = null;
+
+	#[SerializedName(serializedName: 'ttlSec')]
+	private ?int $ttl = null;
+
+	#[Ignore]
+	public function getRequestMethod(): string
+	{
+		return 'POST';
+	}
+
+	#[Ignore]
+	public function getEndpointPath(): string
+	{
+		return '/oneclick/init';
+	}
+
+	#[Ignore]
+	public function getResponseClass(): string
+	{
+		return OneClickInitResponse::class;
+	}
+
+	#[Ignore]
+	public function getNormalizationContext(): array
+	{
+		return [
+			AbstractNormalizer::CALLBACKS => [
+				'merchant' => function (Merchant $value): string {
+					return $value->merchantId;
+				},
+				'totalAmount' => function (?int $value): ?int {
+					return $value;
+				},
+			],
+			AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+			DateTimeNormalizer::FORMAT_KEY => 'c',
+			NormalizerResultOrderingHelper::ORDER => [
+				'merchantId', 'origPayId', 'orderNo', 'dttm',
+				'returnUrl', 'returnMethod',
+				'clientIp', 'totalAmount', 'currency', 'closePayment',
+				'customer', 'order', 'clientInitiated', 'sdkUsed',
+				'merchantData', 'language', 'ttlSec',
+			],
+		];
+	}
+
+	public function getOriginalPaymentId(): string { return $this->originalPaymentId; }
+	public function setOriginalPaymentId(string $originalPaymentId): void { $this->originalPaymentId = $originalPaymentId; }
+
+	public function getOrderNumber(): string { return $this->orderNumber; }
+	public function setOrderNumber(string $orderNumber): void { $this->orderNumber = $orderNumber; }
+
+	public function getReturnUrl(): string { return $this->returnUrl; }
+	public function setReturnUrl(string $returnUrl): void { $this->returnUrl = $returnUrl; }
+
+	public function getReturnMethod(): HttpMethod { return $this->returnMethod; }
+	public function setReturnMethod(HttpMethod $returnMethod): void { $this->returnMethod = $returnMethod; }
+
+	public function getClientIp(): ?string { return $this->clientIp; }
+	public function setClientIp(?string $clientIp): void { $this->clientIp = $clientIp; }
+
+	public function getTotalAmount(): ?int { return $this->totalAmount; }
+	public function setTotalAmount(?int $totalAmount): void { $this->totalAmount = $totalAmount; }
+
+	public function getCurrency(): ?Currency { return $this->currency; }
+	public function setCurrency(?Currency $currency): void { $this->currency = $currency; }
+
+	public function getClosePayment(): ?bool { return $this->closePayment; }
+	public function setClosePayment(?bool $closePayment): void { $this->closePayment = $closePayment; }
+
+	public function getCustomer(): ?Customer { return $this->customer; }
+	public function setCustomer(?Customer $customer): void { $this->customer = $customer; }
+
+	public function getOrder(): ?Order { return $this->order; }
+	public function setOrder(?Order $order): void { $this->order = $order; }
+
+	public function getClientInitiated(): ?bool { return $this->clientInitiated; }
+	public function setClientInitiated(?bool $clientInitiated): void { $this->clientInitiated = $clientInitiated; }
+
+	public function getSdkUsed(): ?bool { return $this->sdkUsed; }
+	public function setSdkUsed(?bool $sdkUsed): void { $this->sdkUsed = $sdkUsed; }
+
+	public function getMerchantData(): ?string { return $this->merchantData; }
+	public function setMerchantData(?string $merchantData): void { $this->merchantData = $merchantData; }
+
+	public function getLanguage(): ?Language { return $this->language; }
+	public function setLanguage(?Language $language): void { $this->language = $language; }
+
+	public function getTtl(): ?int { return $this->ttl; }
+	public function setTtl(?int $ttl): void { $this->ttl = $ttl; }
 }

--- a/src/Requests/OneClickProcessRequest.php
+++ b/src/Requests/OneClickProcessRequest.php
@@ -1,35 +1,58 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace KHTools\VPos\Requests;
 
+use KHTools\VPos\Models\Fingerprint;
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Normalizers\NormalizerResultOrderingHelper;
 use KHTools\VPos\Requests\Traits\MerchantTrait;
+use KHTools\VPos\Requests\Traits\PaymentIdTrait;
+use KHTools\VPos\Responses\OneClickProcessResponse;
 use Symfony\Component\Serializer\Annotation\Ignore;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
 class OneClickProcessRequest implements RequestInterface
 {
-    use MerchantTrait;
+	use MerchantTrait;
+	use PaymentIdTrait;
 
-    #[Ignore]
-    public function getRequestMethod(): string
-    {
-        return 'POST';
-    }
+	private ?Fingerprint $fingerprint = null;
 
-    #[Ignore]
-    public function getEndpointPath(): string
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	#[Ignore]
+	public function getRequestMethod(): string
+	{
+		return 'POST';
+	}
 
-    #[Ignore]
-    public function getResponseClass(): string
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	#[Ignore]
+	public function getEndpointPath(): string
+	{
+		return '/oneclick/process';
+	}
 
-    #[Ignore]
-    public function getNormalizationContext(): array
-    {
-        throw new \LogicException('Not yet implemented');
-    }
+	#[Ignore]
+	public function getResponseClass(): string
+	{
+		return OneClickProcessResponse::class;
+	}
+
+	#[Ignore]
+	public function getNormalizationContext(): array
+	{
+		return [
+			AbstractNormalizer::CALLBACKS => [
+				'merchant' => function (Merchant $value): string {
+					return $value->merchantId;
+				},
+			],
+			AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+			NormalizerResultOrderingHelper::ORDER => [
+				'merchantId', 'payId', 'dttm', 'fingerprint',
+			],
+		];
+	}
+
+	public function getFingerprint(): ?Fingerprint { return $this->fingerprint; }
+	public function setFingerprint(?Fingerprint $fingerprint): void { $this->fingerprint = $fingerprint; }
 }

--- a/src/Requests/PaymentInitRequest.php
+++ b/src/Requests/PaymentInitRequest.php
@@ -60,6 +60,9 @@ class PaymentInitRequest implements RequestInterface
     #[SerializedName(serializedName: 'ttlSec')]
     private ?int $ttl = null;
 
+    #[SerializedName(serializedName: 'customExpiry')]
+    private ?\DateTimeInterface $customExpiry = null;
+
     #[Ignore]
     public function getRequestMethod(): string
     {
@@ -289,6 +292,23 @@ class PaymentInitRequest implements RequestInterface
     }
 
     /**
+     * @return \DateTimeInterface|null
+     */
+    public function getCustomExpiry(): ?\DateTimeInterface
+    {
+        return $this->customExpiry;
+    }
+
+    /**
+     * @param \DateTimeInterface|null $customExpiry
+     */
+    public function setCustomExpiry(?\DateTimeInterface $customExpiry): static
+    {
+        $this->customExpiry = $customExpiry;
+        return $this;
+    }
+
+    /**
      * @return string|null
      */
     public function getMerchantData(): ?string
@@ -336,6 +356,7 @@ class PaymentInitRequest implements RequestInterface
                 'merchantData',
                 'language',
                 'ttlSec',
+                'customExpiry',
             ],
         ];
     }

--- a/src/Requests/PaymentInitRequest.php
+++ b/src/Requests/PaymentInitRequest.php
@@ -302,10 +302,9 @@ class PaymentInitRequest implements RequestInterface
     /**
      * @param \DateTimeInterface|null $customExpiry
      */
-    public function setCustomExpiry(?\DateTimeInterface $customExpiry): static
+    public function setCustomExpiry(?\DateTimeInterface $customExpiry): void
     {
         $this->customExpiry = $customExpiry;
-        return $this;
     }
 
     /**

--- a/src/Responses/ApplePayEchoResponse.php
+++ b/src/Responses/ApplePayEchoResponse.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Responses;
+
+use KHTools\VPos\Models\InitParams;
+use KHTools\VPos\Responses\Traits\CommonResponseTrait;
+
+class ApplePayEchoResponse implements ResponseInterface
+{
+	use CommonResponseTrait;
+
+	private ?InitParams $initParams = null;
+
+	public static function getSignatureFieldOrder(): array
+	{
+		return ['dttm', 'resultCode', 'resultMessage', 'initParams'];
+	}
+
+	public function getInitParams(): ?InitParams { return $this->initParams; }
+	public function setInitParams(?InitParams $initParams): void { $this->initParams = $initParams; }
+}

--- a/src/Responses/ApplePayInitResponse.php
+++ b/src/Responses/ApplePayInitResponse.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Responses;
+
+use KHTools\VPos\Responses\Traits\CommonResponseTrait;
+use KHTools\VPos\Responses\Traits\PaymentActionResponseTrait;
+
+class ApplePayInitResponse implements ResponseInterface
+{
+	use CommonResponseTrait;
+	use PaymentActionResponseTrait;
+
+	public static function getSignatureFieldOrder(): array
+	{
+		return ['payId', 'dttm', 'resultCode', 'resultMessage', 'paymentStatus', 'statusDetail', 'actions'];
+	}
+}

--- a/src/Responses/ApplePayProcessResponse.php
+++ b/src/Responses/ApplePayProcessResponse.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Responses;
+
+use KHTools\VPos\Responses\Traits\CommonResponseTrait;
+use KHTools\VPos\Responses\Traits\PaymentActionResponseTrait;
+
+class ApplePayProcessResponse implements ResponseInterface
+{
+	use CommonResponseTrait;
+	use PaymentActionResponseTrait;
+
+	public static function getSignatureFieldOrder(): array
+	{
+		return ['payId', 'dttm', 'resultCode', 'resultMessage', 'paymentStatus', 'statusDetail', 'actions'];
+	}
+}

--- a/src/Responses/GooglePayEchoResponse.php
+++ b/src/Responses/GooglePayEchoResponse.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Responses;
+
+use KHTools\VPos\Models\InitParams;
+use KHTools\VPos\Responses\Traits\CommonResponseTrait;
+
+class GooglePayEchoResponse implements ResponseInterface
+{
+	use CommonResponseTrait;
+
+	private ?InitParams $initParams = null;
+
+	public static function getSignatureFieldOrder(): array
+	{
+		return ['dttm', 'resultCode', 'resultMessage', 'initParams'];
+	}
+
+	public function getInitParams(): ?InitParams { return $this->initParams; }
+	public function setInitParams(?InitParams $initParams): void { $this->initParams = $initParams; }
+}

--- a/src/Responses/GooglePayInitResponse.php
+++ b/src/Responses/GooglePayInitResponse.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Responses;
+
+use KHTools\VPos\Responses\Traits\CommonResponseTrait;
+use KHTools\VPos\Responses\Traits\PaymentActionResponseTrait;
+
+class GooglePayInitResponse implements ResponseInterface
+{
+	use CommonResponseTrait;
+	use PaymentActionResponseTrait;
+
+	public static function getSignatureFieldOrder(): array
+	{
+		return ['payId', 'dttm', 'resultCode', 'resultMessage', 'paymentStatus', 'statusDetail', 'actions'];
+	}
+}

--- a/src/Responses/GooglePayProcessResponse.php
+++ b/src/Responses/GooglePayProcessResponse.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Responses;
+
+use KHTools\VPos\Responses\Traits\CommonResponseTrait;
+use KHTools\VPos\Responses\Traits\PaymentActionResponseTrait;
+
+class GooglePayProcessResponse implements ResponseInterface
+{
+	use CommonResponseTrait;
+	use PaymentActionResponseTrait;
+
+	public static function getSignatureFieldOrder(): array
+	{
+		return ['payId', 'dttm', 'resultCode', 'resultMessage', 'paymentStatus', 'statusDetail', 'actions'];
+	}
+}

--- a/src/Responses/OneClickEchoResponse.php
+++ b/src/Responses/OneClickEchoResponse.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Responses;
+
+use KHTools\VPos\Responses\Traits\CommonResponseTrait;
+use Symfony\Component\Serializer\Annotation\SerializedName;
+
+class OneClickEchoResponse implements ResponseInterface
+{
+	use CommonResponseTrait;
+
+	#[SerializedName(serializedName: 'origPayId')]
+	private string $originalPaymentId;
+
+	public static function getSignatureFieldOrder(): array
+	{
+		return ['origPayId', 'dttm', 'resultCode', 'resultMessage'];
+	}
+
+	public function getOriginalPaymentId(): string
+	{
+		return $this->originalPaymentId;
+	}
+
+	public function setOriginalPaymentId(string $originalPaymentId): void
+	{
+		$this->originalPaymentId = $originalPaymentId;
+	}
+}

--- a/src/Responses/OneClickInitResponse.php
+++ b/src/Responses/OneClickInitResponse.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Responses;
+
+use KHTools\VPos\Responses\Traits\CommonResponseTrait;
+use KHTools\VPos\Responses\Traits\PaymentActionResponseTrait;
+
+class OneClickInitResponse implements ResponseInterface
+{
+	use CommonResponseTrait;
+	use PaymentActionResponseTrait;
+
+	public static function getSignatureFieldOrder(): array
+	{
+		return ['payId', 'dttm', 'resultCode', 'resultMessage', 'paymentStatus', 'statusDetail', 'actions'];
+	}
+}

--- a/src/Responses/OneClickProcessResponse.php
+++ b/src/Responses/OneClickProcessResponse.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Responses;
+
+use KHTools\VPos\Responses\Traits\CommonResponseTrait;
+use KHTools\VPos\Responses\Traits\PaymentActionResponseTrait;
+
+class OneClickProcessResponse implements ResponseInterface
+{
+	use CommonResponseTrait;
+	use PaymentActionResponseTrait;
+
+	public static function getSignatureFieldOrder(): array
+	{
+		return ['payId', 'dttm', 'resultCode', 'resultMessage', 'paymentStatus', 'statusDetail', 'actions'];
+	}
+}

--- a/src/Responses/PaymentInitResponse.php
+++ b/src/Responses/PaymentInitResponse.php
@@ -16,6 +16,9 @@ class PaymentInitResponse implements ResponseInterface
 
     private ?string $statusDetail = null;
 
+    #[SerializedName(serializedName: 'customerCode')]
+    private ?string $customerCode = null;
+
     /**
      * @return string
      */
@@ -64,8 +67,24 @@ class PaymentInitResponse implements ResponseInterface
         $this->statusDetail = $statusDetail;
     }
 
+    /**
+     * @return string|null
+     */
+    public function getCustomerCode(): ?string
+    {
+        return $this->customerCode;
+    }
+
+    /**
+     * @param string|null $customerCode
+     */
+    public function setCustomerCode(?string $customerCode): void
+    {
+        $this->customerCode = $customerCode;
+    }
+
     public static function getSignatureFieldOrder(): array
     {
-        return ['payId', 'dttm', 'resultCode', 'resultMessage', 'paymentStatus', 'statusDetail'];
+        return ['payId', 'dttm', 'resultCode', 'resultMessage', 'paymentStatus', 'statusDetail', 'customerCode'];
     }
 }

--- a/src/Responses/Traits/PaymentActionResponseTrait.php
+++ b/src/Responses/Traits/PaymentActionResponseTrait.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Responses\Traits;
+
+use Symfony\Component\Serializer\Annotation\SerializedName;
+
+trait PaymentActionResponseTrait
+{
+	#[SerializedName(serializedName: 'payId')]
+	private ?string $paymentId = null;
+
+	private ?int $paymentStatus = null;
+
+	private ?string $statusDetail = null;
+
+	/**
+	 * @var array<string, mixed>|null
+	 */
+	#[SerializedName(serializedName: 'actions')]
+	private ?array $authenticateAction = null;
+
+	public function getPaymentId(): ?string
+	{
+		return $this->paymentId;
+	}
+
+	public function setPaymentId(?string $paymentId): void
+	{
+		$this->paymentId = $paymentId;
+	}
+
+	public function getPaymentStatus(): ?int
+	{
+		return $this->paymentStatus;
+	}
+
+	public function setPaymentStatus(?int $paymentStatus): void
+	{
+		$this->paymentStatus = $paymentStatus;
+	}
+
+	public function getStatusDetail(): ?string
+	{
+		return $this->statusDetail;
+	}
+
+	public function setStatusDetail(?string $statusDetail): void
+	{
+		$this->statusDetail = $statusDetail;
+	}
+
+	/**
+	 * @return array<string, mixed>|null
+	 */
+	public function getAuthenticateAction(): ?array
+	{
+		return $this->authenticateAction;
+	}
+
+	/**
+	 * @param array<string, mixed>|null $authenticateAction
+	 */
+	public function setAuthenticateAction(?array $authenticateAction): void
+	{
+		$this->authenticateAction = $authenticateAction;
+	}
+}

--- a/tests/StaticAnalysis/phpstan.baseline.php
+++ b/tests/StaticAnalysis/phpstan.baseline.php
@@ -61,37 +61,5 @@ $ignoreErrors[] = [
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Models/Enums/PaymentOperation.php',
 ];
-$ignoreErrors[] = [
-	// identifier: property.onlyWritten
-	'message' => '#^Property KHTools\\\\VPos\\\\Requests\\\\ApplePayEchoRequest\\:\\:\\$clientIp is never read, only written\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Requests/ApplePayEchoRequest.php',
-];
-$ignoreErrors[] = [
-	// identifier: property.unusedType
-	// ApplePayEchoRequest properties are written by the Symfony Serializer (external deserialization),
-	// never assigned from PHP code directly — PHPStan cannot see the string assignment path.
-	'message' => '#^Property KHTools\\\\VPos\\\\Requests\\\\ApplePayEchoRequest\\:\\:\\$clientIp \\(string\\|null\\) is never assigned string so it can be removed from the property type\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Requests/ApplePayEchoRequest.php',
-];
-$ignoreErrors[] = [
-	// identifier: property.unusedType
-	'message' => '#^Property KHTools\\\\VPos\\\\Requests\\\\ApplePayEchoRequest\\:\\:\\$payload \\(string\\|null\\) is never assigned string so it can be removed from the property type\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Requests/ApplePayEchoRequest.php',
-];
-$ignoreErrors[] = [
-	// identifier: property.onlyWritten
-	'message' => '#^Property KHTools\\\\VPos\\\\Requests\\\\ApplePayEchoRequest\\:\\:\\$payload is never read, only written\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Requests/ApplePayEchoRequest.php',
-];
-$ignoreErrors[] = [
-	// identifier: property.onlyWritten
-	'message' => '#^Property KHTools\\\\VPos\\\\Requests\\\\ApplePayEchoRequest\\:\\:\\$sdkUsed is never read, only written\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Requests/ApplePayEchoRequest.php',
-];
 
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/tests/Tests/Models/FingerprintTest.php
+++ b/tests/Tests/Models/FingerprintTest.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\Tests\Models;
+
+use KHTools\VPos\Models\Fingerprint;
+use PHPUnit\Framework\TestCase;
+
+class FingerprintTest extends TestCase
+{
+	public function testBrowserDataGetterSetter(): void
+	{
+		$fingerprint = new Fingerprint();
+		$this->assertNull($fingerprint->getBrowserData());
+
+		$fingerprint->setBrowserData(['colorDepth' => 24, 'javaEnabled' => false]);
+		$this->assertSame(['colorDepth' => 24, 'javaEnabled' => false], $fingerprint->getBrowserData());
+	}
+
+	public function testSdkDataGetterSetter(): void
+	{
+		$fingerprint = new Fingerprint();
+		$this->assertNull($fingerprint->getSdkData());
+
+		$fingerprint->setSdkData(['sdkAppID' => 'abc', 'sdkMaxTimeout' => 5]);
+		$this->assertSame(['sdkAppID' => 'abc', 'sdkMaxTimeout' => 5], $fingerprint->getSdkData());
+	}
+}

--- a/tests/Tests/Models/InitParamsTest.php
+++ b/tests/Tests/Models/InitParamsTest.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\Tests\Models;
+
+use KHTools\VPos\Models\InitParams;
+use PHPUnit\Framework\TestCase;
+
+class InitParamsTest extends TestCase
+{
+	public function testGettersSetters(): void
+	{
+		$params = new InitParams();
+		$this->assertNull($params->getMerchantIdentifier());
+		$this->assertNull($params->getMerchantName());
+		$this->assertNull($params->getMerchantCountry());
+		$this->assertNull($params->getSupportedNetworks());
+
+		$params->setMerchantIdentifier('merchant.com.example');
+		$params->setMerchantName('Example Store');
+		$params->setMerchantCountry('CZE');
+		$params->setSupportedNetworks(['VISA', 'MC']);
+
+		$this->assertSame('merchant.com.example', $params->getMerchantIdentifier());
+		$this->assertSame('Example Store', $params->getMerchantName());
+		$this->assertSame('CZE', $params->getMerchantCountry());
+		$this->assertSame(['VISA', 'MC'], $params->getSupportedNetworks());
+	}
+}

--- a/tests/Tests/Normalizers/ApplePayNormalizerTest.php
+++ b/tests/Tests/Normalizers/ApplePayNormalizerTest.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\Tests\Normalizers;
+
+use KHTools\VPos\Models\Enums\Currency;
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Normalizers\CartItemNormalizer;
+use KHTools\VPos\Normalizers\EnumNormalizer;
+use KHTools\VPos\Normalizers\RequestNormalizer;
+use KHTools\VPos\Requests\ApplePayEchoRequest;
+use KHTools\VPos\Requests\ApplePayInitRequest;
+use KHTools\VPos\Requests\ApplePayProcessRequest;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
+use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+class ApplePayNormalizerTest extends TestCase
+{
+	private NormalizerInterface $normalizer;
+
+	protected function setUp(): void
+	{
+		$classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+		$metadataAwareNameConverter = new MetadataAwareNameConverter($classMetadataFactory);
+		$objectNormalizer = new ObjectNormalizer($classMetadataFactory, $metadataAwareNameConverter);
+
+		$this->normalizer = new Serializer([
+			new RequestNormalizer($objectNormalizer),
+			new CartItemNormalizer($objectNormalizer),
+			new EnumNormalizer(),
+			new DateTimeNormalizer(),
+			$objectNormalizer,
+		]);
+	}
+
+	private function merchant(string $id = 'merch01'): Merchant
+	{
+		$m = new Merchant();
+		$m->setMerchantId($id);
+		return $m;
+	}
+
+	public function testApplePayEchoNormalizesMerchantId(): void
+	{
+		$request = new ApplePayEchoRequest();
+		$request->setMerchant($this->merchant());
+
+		$result = $this->normalizer->normalize($request);
+
+		$this->assertSame('merch01', $result['merchantId']);
+		$this->assertArrayHasKey('dttm', $result);
+	}
+
+	public function testApplePayInitNormalizesRequiredFields(): void
+	{
+		$request = new ApplePayInitRequest();
+		$request->setMerchant($this->merchant());
+		$request->setOrderNumber('order123');
+		$request->setTotalAmount(5000);
+		$request->setCurrency(Currency::HUF);
+		$request->setPayload('base64payloadhere');
+		$request->setReturnUrl('https://example.com/return');
+		$request->setReturnMethod(\KHTools\VPos\Models\Enums\HttpMethod::Post);
+
+		$result = $this->normalizer->normalize($request);
+
+		$this->assertSame('merch01', $result['merchantId']);
+		$this->assertSame('order123', $result['orderNo']);
+		$this->assertSame(500000, $result['totalAmount']);
+		$this->assertSame('HUF', $result['currency']);
+		$this->assertSame('base64payloadhere', $result['payload']);
+	}
+
+	public function testApplePayProcessNormalizesPayId(): void
+	{
+		$request = new ApplePayProcessRequest();
+		$request->setMerchant($this->merchant());
+		$request->setPaymentId('pay001');
+
+		$result = $this->normalizer->normalize($request);
+
+		$this->assertSame('merch01', $result['merchantId']);
+		$this->assertSame('pay001', $result['payId']);
+	}
+}

--- a/tests/Tests/Normalizers/GooglePayNormalizerTest.php
+++ b/tests/Tests/Normalizers/GooglePayNormalizerTest.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\Tests\Normalizers;
+
+use KHTools\VPos\Models\Enums\Currency;
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Normalizers\CartItemNormalizer;
+use KHTools\VPos\Normalizers\EnumNormalizer;
+use KHTools\VPos\Normalizers\RequestNormalizer;
+use KHTools\VPos\Requests\GooglePayEchoRequest;
+use KHTools\VPos\Requests\GooglePayInitRequest;
+use KHTools\VPos\Requests\GooglePayProcessRequest;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
+use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+class GooglePayNormalizerTest extends TestCase
+{
+	private NormalizerInterface $normalizer;
+
+	protected function setUp(): void
+	{
+		$classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+		$metadataAwareNameConverter = new MetadataAwareNameConverter($classMetadataFactory);
+		$objectNormalizer = new ObjectNormalizer($classMetadataFactory, $metadataAwareNameConverter);
+
+		$this->normalizer = new Serializer([
+			new RequestNormalizer($objectNormalizer),
+			new CartItemNormalizer($objectNormalizer),
+			new EnumNormalizer(),
+			new DateTimeNormalizer(),
+			$objectNormalizer,
+		]);
+	}
+
+	private function merchant(string $id = 'merch01'): Merchant
+	{
+		$m = new Merchant();
+		$m->setMerchantId($id);
+		return $m;
+	}
+
+	public function testGooglePayEchoNormalizesMerchantId(): void
+	{
+		$request = new GooglePayEchoRequest();
+		$request->setMerchant($this->merchant());
+
+		$result = $this->normalizer->normalize($request);
+
+		$this->assertSame('merch01', $result['merchantId']);
+		$this->assertArrayHasKey('dttm', $result);
+	}
+
+	public function testGooglePayInitNormalizesRequiredFields(): void
+	{
+		$request = new GooglePayInitRequest();
+		$request->setMerchant($this->merchant());
+		$request->setOrderNumber('order123');
+		$request->setTotalAmount(5000);
+		$request->setCurrency(Currency::HUF);
+		$request->setPayload('base64payloadhere');
+		$request->setReturnUrl('https://example.com/return');
+		$request->setReturnMethod(\KHTools\VPos\Models\Enums\HttpMethod::Post);
+
+		$result = $this->normalizer->normalize($request);
+
+		$this->assertSame('merch01', $result['merchantId']);
+		$this->assertSame('order123', $result['orderNo']);
+		$this->assertSame(500000, $result['totalAmount']);
+		$this->assertSame('HUF', $result['currency']);
+		$this->assertSame('base64payloadhere', $result['payload']);
+	}
+
+	public function testGooglePayProcessNormalizesPayId(): void
+	{
+		$request = new GooglePayProcessRequest();
+		$request->setMerchant($this->merchant());
+		$request->setPaymentId('pay001');
+
+		$result = $this->normalizer->normalize($request);
+
+		$this->assertSame('merch01', $result['merchantId']);
+		$this->assertSame('pay001', $result['payId']);
+	}
+}

--- a/tests/Tests/Normalizers/OneClickNormalizerTest.php
+++ b/tests/Tests/Normalizers/OneClickNormalizerTest.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\Tests\Normalizers;
+
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Normalizers\CartItemNormalizer;
+use KHTools\VPos\Normalizers\EnumNormalizer;
+use KHTools\VPos\Normalizers\RequestNormalizer;
+use KHTools\VPos\Requests\OneClickEchoRequest;
+use KHTools\VPos\Requests\OneClickInitRequest;
+use KHTools\VPos\Requests\OneClickProcessRequest;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
+use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+class OneClickNormalizerTest extends TestCase
+{
+	private NormalizerInterface $normalizer;
+
+	protected function setUp(): void
+	{
+		$classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+		$metadataAwareNameConverter = new MetadataAwareNameConverter($classMetadataFactory);
+		$objectNormalizer = new ObjectNormalizer($classMetadataFactory, $metadataAwareNameConverter);
+
+		$this->normalizer = new Serializer([
+			new RequestNormalizer($objectNormalizer),
+			new CartItemNormalizer($objectNormalizer),
+			new EnumNormalizer(),
+			new DateTimeNormalizer(),
+			$objectNormalizer,
+		]);
+	}
+
+	private function merchant(string $id = 'merch01'): Merchant
+	{
+		$m = new Merchant();
+		$m->setMerchantId($id);
+		return $m;
+	}
+
+	public function testOneClickEchoNormalizesOrigPayId(): void
+	{
+		$request = new OneClickEchoRequest();
+		$request->setMerchant($this->merchant());
+		$request->setOriginalPaymentId('pay999');
+
+		$result = $this->normalizer->normalize($request);
+
+		$this->assertSame('merch01', $result['merchantId']);
+		$this->assertSame('pay999', $result['origPayId']);
+		$this->assertArrayHasKey('dttm', $result);
+	}
+
+	public function testOneClickInitNormalizesRequiredFields(): void
+	{
+		$request = new OneClickInitRequest();
+		$request->setMerchant($this->merchant());
+		$request->setOriginalPaymentId('pay999');
+		$request->setOrderNumber('order123');
+		$request->setReturnUrl('https://example.com/return');
+		$request->setReturnMethod(\KHTools\VPos\Models\Enums\HttpMethod::Post);
+
+		$result = $this->normalizer->normalize($request);
+
+		$this->assertSame('merch01', $result['merchantId']);
+		$this->assertSame('pay999', $result['origPayId']);
+		$this->assertSame('order123', $result['orderNo']);
+		$this->assertSame('https://example.com/return', $result['returnUrl']);
+		$this->assertArrayHasKey('dttm', $result);
+	}
+
+	public function testOneClickProcessNormalizesPayId(): void
+	{
+		$request = new OneClickProcessRequest();
+		$request->setMerchant($this->merchant());
+		$request->setPaymentId('pay123');
+
+		$result = $this->normalizer->normalize($request);
+
+		$this->assertSame('merch01', $result['merchantId']);
+		$this->assertSame('pay123', $result['payId']);
+		$this->assertArrayHasKey('dttm', $result);
+	}
+}

--- a/tests/Tests/Normalizers/RequestNormalizerTest.php
+++ b/tests/Tests/Normalizers/RequestNormalizerTest.php
@@ -212,6 +212,12 @@ class RequestNormalizerTest extends TestCase
                 ],
             ],
         ]];
+
+        $paymentInit = new PaymentInitRequest();
+        $paymentInit->setCustomExpiry(new \DateTimeImmutable('2026-01-01T10:00:00+00:00'));
+        yield [$paymentInit, [
+            'customExpiry' => '2026-01-01T10:00:00+00:00',
+        ]];
     }
 
     #[DataProvider(methodName: 'simplePaymentRequestsDataProvider')]

--- a/tests/Tests/Requests/StubRequestTest.php
+++ b/tests/Tests/Requests/StubRequestTest.php
@@ -2,46 +2,12 @@
 
 namespace KHTools\Tests\Requests;
 
-use KHTools\VPos\Requests\GooglePayEchoRequest;
-use KHTools\VPos\Requests\GooglePayInitRequest;
-use KHTools\VPos\Requests\GooglePayProcessRequest;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class StubRequestTest extends TestCase
 {
-    /** @return array<string, array{class-string}> */
-    public static function stubClassProvider(): array
-    {
-        return [
-            'GooglePayInitRequest' => [GooglePayInitRequest::class],
-            'GooglePayProcessRequest' => [GooglePayProcessRequest::class],
-        ];
-    }
-
-    #[DataProvider(methodName: 'stubClassProvider')]
-    public function testGetEndpointPathThrowsLogicException(string $class): void
-    {
-        $request = new $class();
-        $this->expectException(\LogicException::class);
-        $request->getEndpointPath();
-    }
-
-    /** @return array<string, array{class-string}> */
-    public static function allStubClassProvider(): array
-    {
-        return [
-            'GooglePayInitRequest' => [GooglePayInitRequest::class],
-            'GooglePayEchoRequest' => [GooglePayEchoRequest::class],
-            'GooglePayProcessRequest' => [GooglePayProcessRequest::class],
-        ];
-    }
-
-    #[DataProvider(methodName: 'allStubClassProvider')]
-    public function testGetResponseClassThrowsLogicException(string $class): void
-    {
-        $request = new $class();
-        $this->expectException(\LogicException::class);
-        $request->getResponseClass();
-    }
+	public function testNoStubsRemaining(): void
+	{
+		$this->assertTrue(true);
+	}
 }

--- a/tests/Tests/Requests/StubRequestTest.php
+++ b/tests/Tests/Requests/StubRequestTest.php
@@ -2,9 +2,6 @@
 
 namespace KHTools\Tests\Requests;
 
-use KHTools\VPos\Requests\ApplePayEchoRequest;
-use KHTools\VPos\Requests\ApplePayInitRequest;
-use KHTools\VPos\Requests\ApplePayProcessRequest;
 use KHTools\VPos\Requests\GooglePayEchoRequest;
 use KHTools\VPos\Requests\GooglePayInitRequest;
 use KHTools\VPos\Requests\GooglePayProcessRequest;
@@ -17,8 +14,6 @@ class StubRequestTest extends TestCase
     public static function stubClassProvider(): array
     {
         return [
-            'ApplePayInitRequest' => [ApplePayInitRequest::class],
-            'ApplePayProcessRequest' => [ApplePayProcessRequest::class],
             'GooglePayInitRequest' => [GooglePayInitRequest::class],
             'GooglePayProcessRequest' => [GooglePayProcessRequest::class],
         ];
@@ -36,9 +31,6 @@ class StubRequestTest extends TestCase
     public static function allStubClassProvider(): array
     {
         return [
-            'ApplePayInitRequest' => [ApplePayInitRequest::class],
-            'ApplePayEchoRequest' => [ApplePayEchoRequest::class],
-            'ApplePayProcessRequest' => [ApplePayProcessRequest::class],
             'GooglePayInitRequest' => [GooglePayInitRequest::class],
             'GooglePayEchoRequest' => [GooglePayEchoRequest::class],
             'GooglePayProcessRequest' => [GooglePayProcessRequest::class],

--- a/tests/Tests/Requests/StubRequestTest.php
+++ b/tests/Tests/Requests/StubRequestTest.php
@@ -8,9 +8,6 @@ use KHTools\VPos\Requests\ApplePayProcessRequest;
 use KHTools\VPos\Requests\GooglePayEchoRequest;
 use KHTools\VPos\Requests\GooglePayInitRequest;
 use KHTools\VPos\Requests\GooglePayProcessRequest;
-use KHTools\VPos\Requests\OneClickEchoRequest;
-use KHTools\VPos\Requests\OneClickInitRequest;
-use KHTools\VPos\Requests\OneClickProcessRequest;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -20,8 +17,6 @@ class StubRequestTest extends TestCase
     public static function stubClassProvider(): array
     {
         return [
-            'OneClickInitRequest' => [OneClickInitRequest::class],
-            'OneClickProcessRequest' => [OneClickProcessRequest::class],
             'ApplePayInitRequest' => [ApplePayInitRequest::class],
             'ApplePayProcessRequest' => [ApplePayProcessRequest::class],
             'GooglePayInitRequest' => [GooglePayInitRequest::class],
@@ -41,9 +36,6 @@ class StubRequestTest extends TestCase
     public static function allStubClassProvider(): array
     {
         return [
-            'OneClickInitRequest' => [OneClickInitRequest::class],
-            'OneClickEchoRequest' => [OneClickEchoRequest::class],
-            'OneClickProcessRequest' => [OneClickProcessRequest::class],
             'ApplePayInitRequest' => [ApplePayInitRequest::class],
             'ApplePayEchoRequest' => [ApplePayEchoRequest::class],
             'ApplePayProcessRequest' => [ApplePayProcessRequest::class],

--- a/tests/Tests/Responses/PaymentActionResponseTraitTest.php
+++ b/tests/Tests/Responses/PaymentActionResponseTraitTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\Tests\Responses;
+
+use KHTools\VPos\Responses\Traits\PaymentActionResponseTrait;
+use PHPUnit\Framework\TestCase;
+
+class PaymentActionResponseTraitTest extends TestCase
+{
+	private object $subject;
+
+	protected function setUp(): void
+	{
+		$this->subject = new class {
+			use PaymentActionResponseTrait;
+		};
+	}
+
+	public function testPaymentIdGetterSetter(): void
+	{
+		$this->assertNull($this->subject->getPaymentId());
+		$this->subject->setPaymentId('pay001');
+		$this->assertSame('pay001', $this->subject->getPaymentId());
+	}
+
+	public function testPaymentStatusGetterSetter(): void
+	{
+		$this->assertNull($this->subject->getPaymentStatus());
+		$this->subject->setPaymentStatus(2);
+		$this->assertSame(2, $this->subject->getPaymentStatus());
+	}
+
+	public function testStatusDetailGetterSetter(): void
+	{
+		$this->assertNull($this->subject->getStatusDetail());
+		$this->subject->setStatusDetail('detail string');
+		$this->assertSame('detail string', $this->subject->getStatusDetail());
+	}
+
+	public function testAuthenticateActionGetterSetter(): void
+	{
+		$this->assertNull($this->subject->getAuthenticateAction());
+		$this->subject->setAuthenticateAction(['redirectUrl' => 'https://example.com']);
+		$this->assertSame(['redirectUrl' => 'https://example.com'], $this->subject->getAuthenticateAction());
+	}
+}

--- a/tests/Tests/Responses/PaymentInitResponseTest.php
+++ b/tests/Tests/Responses/PaymentInitResponseTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\Tests\Responses;
+
+use KHTools\VPos\Responses\PaymentInitResponse;
+use PHPUnit\Framework\TestCase;
+
+class PaymentInitResponseTest extends TestCase
+{
+    public function testCustomerCodeIsStoredAndRetrieved(): void
+    {
+        $response = new PaymentInitResponse();
+        $response->setCustomerCode('CUST001');
+        $this->assertSame('CUST001', $response->getCustomerCode());
+    }
+
+    public function testCustomerCodeDefaultsToNull(): void
+    {
+        $response = new PaymentInitResponse();
+        $this->assertNull($response->getCustomerCode());
+    }
+}


### PR DESCRIPTION
## Summary

- Implemented all remaining payment gateway endpoints: OneClick (echo/init/process), ApplePay (echo/init/process), GooglePay (echo/init/process)
- Added `Fingerprint` and `InitParams` models and `PaymentActionResponseTrait` shared by all Init/Process responses
- Added missing fields: `customExpiry` on `PaymentInitRequest`, `customerCode` on `PaymentInitResponse`, `trxUsage` on `Order`
- Updated README support chart — all 16 endpoints now marked as supported

## Test Plan

- [ ] All 150 tests pass (`phpunit-11 --colors=always`)
- [ ] PHPStan level 8 zero errors (`vendor/bin/phpstan analyse --memory-limit=1G`)
- [ ] OneClick/ApplePay/GooglePay normalizer tests cover field names, amount conversion (bcmath), and serialized name aliases
- [ ] `StubRequestTest.php` is now empty — all previously stubbed endpoints are fully implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)