### PR TITLE
test: increase coverage with SignatureProvider, request metadata, normalizer and VPosClient tests

### DIFF
--- a/docs/superpowers/specs/2026-04-11-coverage-improvement-design.md
+++ b/docs/superpowers/specs/2026-04-11-coverage-improvement-design.md
@@ -1,0 +1,229 @@
+# Coverage Improvement — Design Spec
+
+**Date:** 2026-04-11
+
+---
+
+## Goal
+
+Increase meaningful test coverage by adding real, behaviour-verifying tests. Not metric inflation — every test must catch a real bug if the implementation is wrong.
+
+## Current State
+
+Library tests (excluding Bundle): **~52% line coverage, 37% method coverage** (117 tests).
+
+Biggest uncovered areas:
+- `SignatureProvider` — 0% (core RSA signing / verification logic)
+- `VPosClient` — 0% (main entry point: signing, normalizing, HTTP, response deserialization)
+- Request classes — 25–50% (`getEndpointPath()`, `getRequestMethod()`, `getResponseClass()` never called in tests)
+- `RequestNormalizer::supportsNormalization()` / `ResponseNormalizer::supportsDenormalization()` — uncalled
+
+## Approach
+
+Four tasks, bottom-up by complexity. Pure unit tests first, integration last.
+
+---
+
+## Task 1: SignatureProvider unit tests
+
+**File:** `tests/Tests/SignatureProviderTest.php`
+
+**Fixtures already present:** `tests/Tests/Fixtures/test1_private_key.pem`, `tests/Tests/Fixtures/test1_public_key.pem`, `tests/Tests/Fixtures/test2_private_key.pem`, `tests/Tests/Fixtures/test2_public_key.pem`
+
+### Test cases
+
+**`sign()` produces a valid RSA-SHA256 signature**
+
+```php
+$provider = new SignatureProvider(
+    ['M123' => new PrivateKey(__DIR__.'/../Fixtures/test1_private_key.pem')],
+    __DIR__.'/../Fixtures/test1_public_key.pem',
+);
+$merchant = new Merchant();
+$merchant->merchantId = 'M123';
+$payload = ['merchantId' => 'M123', 'dttm' => '20240101120000', 'orderNo' => '1001'];
+
+$signature = $provider->sign($merchant, $payload);
+
+$decoded = base64_decode($signature, strict: true);
+$pubKey = openssl_pkey_get_public(file_get_contents(__DIR__.'/../Fixtures/test1_public_key.pem'));
+$result = openssl_verify('M123|20240101120000|1001', $decoded, $pubKey, OPENSSL_ALGO_SHA256);
+$this->assertSame(1, $result);
+```
+
+**`sign()` accepts a private key path string via `addPrivateKey()`**
+
+Call `addPrivateKey('M123', '/path/to/key.pem')` (string, not PrivateKey object) — verify it loads lazily and `sign()` succeeds without error.
+
+**`verify()` returns true for correctly signed content**
+
+Sign a payload with `test1_private_key.pem`. Construct a new `SignatureProvider` with `test1_public_key.pem` as the MIPS key. Call `verify($payload, $signature)` → `true`.
+
+**`verify()` returns false for tampered content**
+
+Sign a payload, then modify one field value. `verify()` → `false`.
+
+**`verify()` throws `SSLErrorException` for invalid base64 signature**
+
+Pass `'not-base64!!'` as the signature → `SSLErrorException`.
+
+**`buildStringContentToSign` behaviour (tested indirectly via `sign()` + manual `openssl_verify`)**
+
+Test cases that verify the string-building rules:
+
+- Boolean `true` serializes as `'true'`, `false` as `'false'`
+- The `'signature'` key is excluded from the signed string
+- Nested arrays are flattened recursively (values concatenated with `|`)
+
+For each case: call `sign()`, then verify the signature against the manually constructed expected string using `openssl_verify()` directly — if the expected string was wrong, verification fails.
+
+---
+
+## Task 2: Request metadata tests
+
+**File:** `tests/Tests/Requests/RequestMetadataTest.php`
+
+Single data-driven test class. One data provider row per concrete request class.
+
+### Data provider
+
+| Class | Method | Path | Response class |
+|---|---|---|---|
+| `EchoRequest` | `POST` | `/echo` | `EchoResponse` |
+| `PaymentInitRequest` | `POST` | `/payment/init` | `PaymentInitResponse` |
+| `PaymentStatusRequest` | `GET` | `/payment/status/{merchantId}/{payId}/{dttm}/{signature}` | `PaymentStatusResponse` |
+| `PaymentProcessRequest` | `GET` | `/payment/process/{merchantId}/{payId}/{dttm}/{signature}` | *(throws)* |
+| `PaymentCloseRequest` | `PUT` | `/payment/close` | `PaymentCloseResponse` |
+| `PaymentReverseRequest` | `PUT` | `/payment/reverse` | `PaymentReverseResponse` |
+| `PaymentRefundRequest` | `PUT` | `/payment/refund` | `PaymentRefundResponse` |
+| `OneClickEchoRequest` | `POST` | `/oneclick/echo` | `OneClickEchoResponse` |
+| `OneClickInitRequest` | `POST` | `/oneclick/init` | `OneClickInitResponse` |
+| `OneClickProcessRequest` | `POST` | `/oneclick/process` | `OneClickProcessResponse` |
+| `ApplePayEchoRequest` | `POST` | `/applepay/echo` | `ApplePayEchoResponse` |
+| `ApplePayInitRequest` | `POST` | `/applepay/init` | `ApplePayInitResponse` |
+| `ApplePayProcessRequest` | `POST` | `/applepay/process` | `ApplePayProcessResponse` |
+| `GooglePayEchoRequest` | `POST` | `/googlepay/echo` | `GooglePayEchoResponse` |
+| `GooglePayInitRequest` | `POST` | `/googlepay/init` | `GooglePayInitResponse` |
+| `GooglePayProcessRequest` | `POST` | `/googlepay/process` | `GooglePayProcessResponse` |
+
+### Test methods
+
+**`testRequestMethod(string $class, string $expectedMethod)`**
+Instantiate the class with `new $class()`, assert `getRequestMethod() === $expectedMethod`.
+
+**`testEndpointPath(string $class, string $expectedPath)`**
+Same instantiation, assert `getEndpointPath() === $expectedPath`.
+
+**`testResponseClass(string $class, string $expectedResponseClass)`**
+Assert `getResponseClass() === $expectedResponseClass` AND that `$expectedResponseClass` is a class implementing `ResponseInterface`.
+
+**`testPaymentProcessRequestResponseClassThrows()`**
+Separate test (not data-driven): `(new PaymentProcessRequest())->getResponseClass()` → `\BadFunctionCallException`.
+
+---
+
+## Task 3: Normalizer support method tests
+
+**Files:** extend existing `tests/Tests/Normalizers/RequestNormalizerTest.php` and `tests/Tests/Normalizers/ResponseNormalizerTest.php`
+
+### `RequestNormalizerTest` additions
+
+```php
+public function testSupportsNormalizationForRequestInterface(): void
+{
+    $normalizer = new RequestNormalizer($this->objectNormalizer());
+    $this->assertTrue($normalizer->supportsNormalization(new PaymentInitRequest()));
+}
+
+public function testSupportsNormalizationReturnsFalseForOther(): void
+{
+    $normalizer = new RequestNormalizer($this->objectNormalizer());
+    $this->assertFalse($normalizer->supportsNormalization(new \stdClass()));
+}
+```
+
+`objectNormalizer()` is an extraction of the `setUp()` factory code into a helper method.
+
+### `ResponseNormalizerTest` additions
+
+Extract the `ResponseNormalizer` construction from `setUp()` into a private helper `buildResponseNormalizer(): ResponseNormalizer`, then use it in the new tests:
+
+```php
+public function testSupportsDenormalizationForResponseInterface(): void
+{
+    $normalizer = $this->buildResponseNormalizer();
+    $this->assertTrue($normalizer->supportsDenormalization([], PaymentStatusResponse::class));
+}
+
+public function testSupportsDenormalizationReturnsFalseForOther(): void
+{
+    $normalizer = $this->buildResponseNormalizer();
+    $this->assertFalse($normalizer->supportsDenormalization([], \stdClass::class));
+}
+```
+
+---
+
+## Task 4: VPosClient integration tests
+
+**File:** `tests/Tests/VPosClientTest.php`
+
+### Container setup
+
+`ServiceSubscriberTrait` reads services via `$this->container->get(__METHOD__)` where `__METHOD__` is the fully-qualified method name. The container must satisfy these keys:
+
+```
+KHTools\VPos\VPosClient::getSignatureProvider  → SignatureProviderInterface
+KHTools\VPos\VPosClient::getNormalizer         → NormalizerInterface
+KHTools\VPos\VPosClient::getDenormalizer       → DenormalizerInterface
+KHTools\VPos\VPosClient::getSerializer         → SerializerInterface
+KHTools\VPos\VPosClient::getHttpClient         → Psr\Http\Client\ClientInterface
+KHTools\VPos\VPosClient::getRequestFactory     → RequestFactoryInterface
+KHTools\VPos\VPosClient::getStreamFactory      → StreamFactoryInterface
+```
+
+Use a minimal PSR container (anonymous class implementing `Psr\Container\ContainerInterface`) populated in `setUp()`.
+
+PSR-18 mock HTTP client: `Symfony\Component\HttpClient\MockHttpClient` + `Symfony\Component\HttpClient\Psr18Client` adapter (already in `require-dev`).
+
+Real services:
+- `SignatureProvider` with `test1_private_key.pem` (merchant ID `'M123'`) and `test1_public_key.pem` as MIPS key
+- Full Symfony `Serializer` with all 6 normalizers + `ResponseNormalizer` + `RequestNormalizer`
+
+A `buildClient(callable $mockResponseFactory): VPosClient` helper method builds the client with the given mock HTTP behaviour.
+
+### Test cases
+
+**`testSendPostRequest()` — PaymentInitRequest → PaymentInitResponse**
+
+Mock HTTP returns a canned JSON matching the `PaymentInitResponse` signature field order (`payId`, `dttm`, `resultCode`, `resultMessage`, `paymentStatus`, `authCode`). Call `$client->send($request)`, assert the response object has correct field values. No signature verification in the mock response (SignatureProvider in `ResponseNormalizer` uses the MIPS public key, which won't match a test-signed response — pass an empty `signature` field; the ResponseNormalizer skips verification when signature is absent or when SignatureProvider is constructed with an empty MIPS key path).
+
+**`testSendGetRequest()` — PaymentStatusRequest**
+
+Set `payId` on the request, call `send()`. Capture the PSR-7 request URI the mock received — assert it contains the `payId` in the path and `signature` is URL-encoded (no `+` or `=` unencoded).
+
+**`testSendThrowsOnHttpError()`**
+
+Mock returns HTTP 400 with `Content-Type: application/json` body. Assert a `HttpErrorException` subclass is thrown.
+
+**`testGetPaymentUrlWithPaymentProcessRequest()`**
+
+Call `getPaymentUrlWithPaymentProcessRequest($request)`. Assert the returned URL:
+- Starts with `https://api.khpos.hu/api/v1.0/payment/process/`
+- Contains the `payId` in the path
+- Contains a URL-encoded `signature` query parameter
+
+**`testGetPaymentUrlUsesTestEndpointWhenTestModeEnabled()`**
+
+Construct `VPosClient` with `isTest: true`. Assert the URL starts with `https://api.sandbox.khpos.hu/api/v1.0/`.
+
+**`testInitResponseWithArray()`**
+
+Pass a raw array to `initResponseWithArray($array, PaymentStatusResponse::class)`. Assert the returned object is a `PaymentStatusResponse` with the correct field values. No HTTP involved.
+
+---
+
+## Notes
+
+- `PaymentProcessRequest::getResponseClass()` intentionally throws `BadFunctionCallException` — its use via `VPosClient` goes through `getPaymentUrlWithPaymentProcessRequest()` not `send()`, so no response class is needed.
+- `ResponseNormalizer` signature verification: when `verify()` would fail against a non-MIPS-signed test response, pass a `SignatureProvider` constructed with the same test key pair for both signing and verification, or use a `SignatureProvider` subclass that skips verification. The simplest approach: sign the canned response JSON with `test1_private_key.pem` in the test setup and use `test1_public_key.pem` as the MIPS key — making the verification pass end-to-end.

--- a/tests/Tests/Normalizers/RequestNormalizerTest.php
+++ b/tests/Tests/Normalizers/RequestNormalizerTest.php
@@ -324,4 +324,24 @@ class RequestNormalizerTest extends TestCase
             'merchantId' => 'abc123',
         ], $normalized);
     }
+
+    private function buildObjectNormalizer(): ObjectNormalizer
+    {
+        $loader = new AttributeLoader();
+        $classMetadataFactory = new ClassMetadataFactory($loader);
+        $metadataAwareNameConverter = new MetadataAwareNameConverter($classMetadataFactory);
+        return new ObjectNormalizer($classMetadataFactory, $metadataAwareNameConverter);
+    }
+
+    public function testSupportsNormalizationForRequestInterface(): void
+    {
+        $normalizer = new RequestNormalizer($this->buildObjectNormalizer());
+        $this->assertTrue($normalizer->supportsNormalization(new PaymentInitRequest()));
+    }
+
+    public function testSupportsNormalizationReturnsFalseForNonRequest(): void
+    {
+        $normalizer = new RequestNormalizer($this->buildObjectNormalizer());
+        $this->assertFalse($normalizer->supportsNormalization(new \stdClass()));
+    }
 }

--- a/tests/Tests/Normalizers/ResponseNormalizerTest.php
+++ b/tests/Tests/Normalizers/ResponseNormalizerTest.php
@@ -24,7 +24,8 @@ class ResponseNormalizerTest extends TestCase
     {
         $objectNormalizer = $this->buildObjectNormalizer();
         $enumNormalizer = new EnumNormalizer();
-        $signatureProvider = new SignatureProvider([], './');
+        // Using test fixture key as MIPS key — only for denormalization tests that omit the 'signature' field
+        $signatureProvider = new SignatureProvider([], __DIR__ . '/../Fixtures/test1_public_key.pem');
 
         $this->normalizer = new Serializer([
             new ResponseNormalizer($signatureProvider, $objectNormalizer),

--- a/tests/Tests/Normalizers/ResponseNormalizerTest.php
+++ b/tests/Tests/Normalizers/ResponseNormalizerTest.php
@@ -22,13 +22,8 @@ class ResponseNormalizerTest extends TestCase
 
     protected function setUp(): void
     {
-        $loader = new AttributeLoader();
-        $classMetadataFactory = new ClassMetadataFactory($loader);
-        $metadataAwareNameConverter = new MetadataAwareNameConverter($classMetadataFactory);
-        $extractor = new PropertyInfoExtractor([], [new ReflectionExtractor()]);
-
+        $objectNormalizer = $this->buildObjectNormalizer();
         $enumNormalizer = new EnumNormalizer();
-        $objectNormalizer = new ObjectNormalizer($classMetadataFactory, $metadataAwareNameConverter, null, $extractor);
         $signatureProvider = new SignatureProvider([], './');
 
         $this->normalizer = new Serializer([
@@ -38,6 +33,39 @@ class ResponseNormalizerTest extends TestCase
         ]);
 
         $objectNormalizer->setSerializer($this->normalizer);
+    }
+
+    private function buildObjectNormalizer(): ObjectNormalizer
+    {
+        $loader = new AttributeLoader();
+        $classMetadataFactory = new ClassMetadataFactory($loader);
+        $metadataAwareNameConverter = new MetadataAwareNameConverter($classMetadataFactory);
+        $extractor = new PropertyInfoExtractor([], [new ReflectionExtractor()]);
+        return new ObjectNormalizer($classMetadataFactory, $metadataAwareNameConverter, null, $extractor);
+    }
+
+    /**
+     * Builds a standalone ResponseNormalizer suitable for supportsNormalization/supportsDenormalization checks.
+     * Note: ObjectNormalizer is NOT wired to a Serializer — do not use this helper for actual denormalization.
+     */
+    private function buildResponseNormalizer(): ResponseNormalizer
+    {
+        return new ResponseNormalizer(
+            new SignatureProvider([], __DIR__ . '/../Fixtures/test1_public_key.pem'),
+            $this->buildObjectNormalizer(),
+        );
+    }
+
+    public function testSupportsDenormalizationForResponseClass(): void
+    {
+        $normalizer = $this->buildResponseNormalizer();
+        $this->assertTrue($normalizer->supportsDenormalization([], PaymentStatusResponse::class));
+    }
+
+    public function testSupportsDenormalizationReturnsFalseForNonResponseClass(): void
+    {
+        $normalizer = $this->buildResponseNormalizer();
+        $this->assertFalse($normalizer->supportsDenormalization([], \stdClass::class));
     }
 
     public function testPaymentStatusResponse()

--- a/tests/Tests/Requests/RequestMetadataTest.php
+++ b/tests/Tests/Requests/RequestMetadataTest.php
@@ -1,0 +1,112 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\Tests\Requests;
+
+use KHTools\VPos\Requests\ApplePayEchoRequest;
+use KHTools\VPos\Requests\ApplePayInitRequest;
+use KHTools\VPos\Requests\ApplePayProcessRequest;
+use KHTools\VPos\Requests\EchoRequest;
+use KHTools\VPos\Requests\GooglePayEchoRequest;
+use KHTools\VPos\Requests\GooglePayInitRequest;
+use KHTools\VPos\Requests\GooglePayProcessRequest;
+use KHTools\VPos\Requests\OneClickEchoRequest;
+use KHTools\VPos\Requests\OneClickInitRequest;
+use KHTools\VPos\Requests\OneClickProcessRequest;
+use KHTools\VPos\Requests\PaymentCloseRequest;
+use KHTools\VPos\Requests\PaymentInitRequest;
+use KHTools\VPos\Requests\PaymentProcessRequest;
+use KHTools\VPos\Requests\PaymentRefundRequest;
+use KHTools\VPos\Requests\PaymentReverseRequest;
+use KHTools\VPos\Requests\PaymentStatusRequest;
+use KHTools\VPos\Responses\ApplePayEchoResponse;
+use KHTools\VPos\Responses\ApplePayInitResponse;
+use KHTools\VPos\Responses\ApplePayProcessResponse;
+use KHTools\VPos\Responses\EchoResponse;
+use KHTools\VPos\Responses\GooglePayEchoResponse;
+use KHTools\VPos\Responses\GooglePayInitResponse;
+use KHTools\VPos\Responses\GooglePayProcessResponse;
+use KHTools\VPos\Responses\OneClickEchoResponse;
+use KHTools\VPos\Responses\OneClickInitResponse;
+use KHTools\VPos\Responses\OneClickProcessResponse;
+use KHTools\VPos\Responses\PaymentCloseResponse;
+use KHTools\VPos\Responses\PaymentInitResponse;
+use KHTools\VPos\Responses\PaymentRefundResponse;
+use KHTools\VPos\Responses\PaymentReverseResponse;
+use KHTools\VPos\Responses\PaymentStatusResponse;
+use KHTools\VPos\Responses\ResponseInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class RequestMetadataTest extends TestCase
+{
+    /**
+     * @return array<string, array{class-string, string, string, string}>
+     */
+    public static function requestMetadataProvider(): array
+    {
+        return [
+            'EchoRequest'             => [EchoRequest::class,             'POST', '/echo',                                                          EchoResponse::class],
+            'PaymentInitRequest'      => [PaymentInitRequest::class,      'POST', '/payment/init',                                                   PaymentInitResponse::class],
+            'PaymentStatusRequest'    => [PaymentStatusRequest::class,    'GET',  '/payment/status/{merchantId}/{payId}/{dttm}/{signature}',          PaymentStatusResponse::class],
+            'PaymentCloseRequest'     => [PaymentCloseRequest::class,     'PUT',  '/payment/close',                                                   PaymentCloseResponse::class],
+            'PaymentReverseRequest'   => [PaymentReverseRequest::class,   'PUT',  '/payment/reverse',                                                 PaymentReverseResponse::class],
+            'PaymentRefundRequest'    => [PaymentRefundRequest::class,    'PUT',  '/payment/refund',                                                  PaymentRefundResponse::class],
+            'OneClickEchoRequest'     => [OneClickEchoRequest::class,     'POST', '/oneclick/echo',                                                   OneClickEchoResponse::class],
+            'OneClickInitRequest'     => [OneClickInitRequest::class,     'POST', '/oneclick/init',                                                   OneClickInitResponse::class],
+            'OneClickProcessRequest'  => [OneClickProcessRequest::class,  'POST', '/oneclick/process',                                                OneClickProcessResponse::class],
+            'ApplePayEchoRequest'     => [ApplePayEchoRequest::class,     'POST', '/applepay/echo',                                                   ApplePayEchoResponse::class],
+            'ApplePayInitRequest'     => [ApplePayInitRequest::class,     'POST', '/applepay/init',                                                   ApplePayInitResponse::class],
+            'ApplePayProcessRequest'  => [ApplePayProcessRequest::class,  'POST', '/applepay/process',                                                ApplePayProcessResponse::class],
+            'GooglePayEchoRequest'    => [GooglePayEchoRequest::class,    'POST', '/googlepay/echo',                                                  GooglePayEchoResponse::class],
+            'GooglePayInitRequest'    => [GooglePayInitRequest::class,    'POST', '/googlepay/init',                                                  GooglePayInitResponse::class],
+            'GooglePayProcessRequest' => [GooglePayProcessRequest::class, 'POST', '/googlepay/process',                                               GooglePayProcessResponse::class],
+            'PaymentProcessRequest'   => [PaymentProcessRequest::class,   'GET',  '/payment/process/{merchantId}/{payId}/{dttm}/{signature}',          ''],
+        ];
+    }
+
+    /**
+     * @param class-string $requestClass
+     */
+    #[DataProvider('requestMetadataProvider')]
+    public function testRequestMethod(string $requestClass, string $expectedMethod, string $expectedPath, string $expectedResponseClass): void
+    {
+        $request = new $requestClass();
+        $this->assertSame($expectedMethod, $request->getRequestMethod());
+    }
+
+    /**
+     * @param class-string $requestClass
+     */
+    #[DataProvider('requestMetadataProvider')]
+    public function testEndpointPath(string $requestClass, string $expectedMethod, string $expectedPath, string $expectedResponseClass): void
+    {
+        $request = new $requestClass();
+        $this->assertSame($expectedPath, $request->getEndpointPath());
+    }
+
+    /**
+     * @param class-string $requestClass
+     * @param class-string $expectedResponseClass
+     */
+    #[DataProvider('requestMetadataProvider')]
+    public function testResponseClass(string $requestClass, string $expectedMethod, string $expectedPath, string $expectedResponseClass): void
+    {
+        if ($expectedResponseClass === '') {
+            $this->markTestSkipped('PaymentProcessRequest::getResponseClass() intentionally throws — tested separately');
+        }
+
+        $request = new $requestClass();
+        $actual = $request->getResponseClass();
+        $this->assertSame($expectedResponseClass, $actual);
+        $this->assertTrue(
+            is_a($actual, ResponseInterface::class, true),
+            sprintf('%s must implement ResponseInterface', $actual)
+        );
+    }
+
+    public function testPaymentProcessRequestResponseClassThrows(): void
+    {
+        $this->expectException(\BadFunctionCallException::class);
+        (new PaymentProcessRequest())->getResponseClass();
+    }
+}

--- a/tests/Tests/SignatureProviderTest.php
+++ b/tests/Tests/SignatureProviderTest.php
@@ -1,0 +1,143 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\Tests;
+
+use KHTools\VPos\Exceptions\SSLErrorException;
+use KHTools\VPos\Keys\PrivateKey;
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\SignatureProvider;
+use PHPUnit\Framework\TestCase;
+
+class SignatureProviderTest extends TestCase
+{
+    private const FIXTURES = __DIR__ . '/Fixtures';
+
+    private function merchant(string $id = 'M123'): Merchant
+    {
+        $m = new Merchant();
+        $m->merchantId = $id;
+        return $m;
+    }
+
+    private function provider(): SignatureProvider
+    {
+        return new SignatureProvider(
+            ['M123' => new PrivateKey(self::FIXTURES . '/test1_private_key.pem')],
+            self::FIXTURES . '/test1_public_key.pem',
+        );
+    }
+
+    public function testSignProducesValidRsaSha256Signature(): void
+    {
+        $provider = $this->provider();
+        $payload = ['merchantId' => 'M123', 'dttm' => '20240101120000', 'orderNo' => '1001'];
+
+        $signature = $provider->sign($this->merchant(), $payload);
+
+        $decoded = base64_decode($signature, true);
+        $this->assertNotFalse($decoded, 'Signature must be valid base64');
+
+        $pubKey = openssl_pkey_get_public(file_get_contents(self::FIXTURES . '/test1_public_key.pem'));
+        $result = openssl_verify('M123|20240101120000|1001', $decoded, $pubKey, OPENSSL_ALGO_SHA256);
+        $this->assertSame(1, $result, 'openssl_verify must confirm the signature');
+    }
+
+    public function testSignAcceptsPrivateKeyPathString(): void
+    {
+        $provider = new SignatureProvider([], self::FIXTURES . '/test1_public_key.pem');
+        $provider->addPrivateKey('M123', self::FIXTURES . '/test1_private_key.pem');
+
+        // If lazy loading works, sign() must not throw
+        $signature = $provider->sign($this->merchant(), ['merchantId' => 'M123']);
+        $this->assertNotEmpty($signature);
+        $this->assertNotFalse(base64_decode($signature, true), 'Signature must be valid base64');
+    }
+
+    public function testVerifyReturnsTrueForCorrectSignature(): void
+    {
+        $provider = $this->provider();
+        $payload = ['merchantId' => 'M123', 'dttm' => '20240101120000'];
+
+        $signature = $provider->sign($this->merchant(), $payload);
+
+        // New provider with test1_public_key as MIPS key — same key used for signing
+        $verifier = new SignatureProvider([], self::FIXTURES . '/test1_public_key.pem');
+        $this->assertTrue($verifier->verify($payload, $signature));
+    }
+
+    public function testVerifyReturnsFalseForTamperedContent(): void
+    {
+        $provider = $this->provider();
+        $payload = ['merchantId' => 'M123', 'dttm' => '20240101120000'];
+        $signature = $provider->sign($this->merchant(), $payload);
+
+        $tampered = $payload;
+        $tampered['merchantId'] = 'EVIL';
+
+        $verifier = new SignatureProvider([], self::FIXTURES . '/test1_public_key.pem');
+        $this->assertFalse($verifier->verify($tampered, $signature));
+    }
+
+    public function testVerifyThrowsForInvalidBase64Signature(): void
+    {
+        $provider = new SignatureProvider([], self::FIXTURES . '/test1_public_key.pem');
+        $this->expectException(SSLErrorException::class);
+        $provider->verify(['merchantId' => 'M123'], '!!!!');
+    }
+
+    public function testSignBooleanTrueSerializesAsStringTrue(): void
+    {
+        $provider = $this->provider();
+        $payload = ['merchantId' => 'M123', 'flag' => true];
+
+        $signature = $provider->sign($this->merchant(), $payload);
+        $decoded = base64_decode($signature, true);
+        $pubKey = openssl_pkey_get_public(file_get_contents(self::FIXTURES . '/test1_public_key.pem'));
+
+        // 'true' string literal expected (not '1')
+        $result = openssl_verify('M123|true', $decoded, $pubKey, OPENSSL_ALGO_SHA256);
+        $this->assertSame(1, $result);
+    }
+
+    public function testSignBooleanFalseSerializesAsStringFalse(): void
+    {
+        $provider = $this->provider();
+        $payload = ['merchantId' => 'M123', 'flag' => false];
+
+        $signature = $provider->sign($this->merchant(), $payload);
+        $decoded = base64_decode($signature, true);
+        $pubKey = openssl_pkey_get_public(file_get_contents(self::FIXTURES . '/test1_public_key.pem'));
+
+        $result = openssl_verify('M123|false', $decoded, $pubKey, OPENSSL_ALGO_SHA256);
+        $this->assertSame(1, $result);
+    }
+
+    public function testSignSkipsSignatureKey(): void
+    {
+        $provider = $this->provider();
+        // 'signature' key must be excluded from the signed string
+        $payload = ['merchantId' => 'M123', 'signature' => 'should-be-skipped'];
+
+        $signature = $provider->sign($this->merchant(), $payload);
+        $decoded = base64_decode($signature, true);
+        $pubKey = openssl_pkey_get_public(file_get_contents(self::FIXTURES . '/test1_public_key.pem'));
+
+        // Only 'M123' — the signature value is NOT in the signed string
+        $result = openssl_verify('M123', $decoded, $pubKey, OPENSSL_ALGO_SHA256);
+        $this->assertSame(1, $result);
+    }
+
+    public function testSignFlattensNestedArraysRecursively(): void
+    {
+        $provider = $this->provider();
+        $payload = ['merchantId' => 'M123', 'nested' => ['a' => 'x', 'b' => 'y']];
+
+        $signature = $provider->sign($this->merchant(), $payload);
+        $decoded = base64_decode($signature, true);
+        $pubKey = openssl_pkey_get_public(file_get_contents(self::FIXTURES . '/test1_public_key.pem'));
+
+        // PHP preserves array insertion order; 'a' is visited before 'b' deterministically
+        $result = openssl_verify('M123|x|y', $decoded, $pubKey, OPENSSL_ALGO_SHA256);
+        $this->assertSame(1, $result);
+    }
+}

--- a/tests/Tests/VPosClientTest.php
+++ b/tests/Tests/VPosClientTest.php
@@ -1,0 +1,267 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\Tests;
+
+use KHTools\VPos\Exceptions\ClientErrorException;
+use KHTools\VPos\Keys\PrivateKey;
+use KHTools\VPos\Models\Enums\Currency;
+use KHTools\VPos\Models\Enums\HttpMethod;
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Normalizers\AddressNormalizer;
+use KHTools\VPos\Normalizers\CartItemNormalizer;
+use KHTools\VPos\Normalizers\EnumNormalizer;
+use KHTools\VPos\Normalizers\HttpErrorNormalizer;
+use KHTools\VPos\Normalizers\RequestNormalizer;
+use KHTools\VPos\Normalizers\ResponseNormalizer;
+use KHTools\VPos\Requests\PaymentInitRequest;
+use KHTools\VPos\Requests\PaymentProcessRequest;
+use KHTools\VPos\Requests\PaymentStatusRequest;
+use KHTools\VPos\Responses\PaymentInitResponse;
+use KHTools\VPos\Responses\PaymentStatusResponse;
+use KHTools\VPos\SignatureProvider;
+use KHTools\VPos\VPosClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Psr18Client;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
+use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+class VPosClientTest extends TestCase
+{
+    private const FIXTURES = __DIR__ . '/Fixtures';
+    private const MERCHANT_ID = 'M123';
+
+    private function merchant(): Merchant
+    {
+        $m = new Merchant();
+        $m->merchantId = self::MERCHANT_ID;
+        return $m;
+    }
+
+    /**
+     * Builds a VPosClient with real Serializer + SignatureProvider and a mock HTTP layer.
+     * Pass MockResponse instances for the mock HTTP layer.
+     * Returns both the client and the MockHttpClient so tests can inspect sent requests.
+     *
+     * @return array{VPosClient, MockHttpClient}
+     */
+    private function buildClient(MockResponse ...$mockResponses): array
+    {
+        $mockHttpClient = new MockHttpClient($mockResponses);
+        $psr18 = new Psr18Client($mockHttpClient);
+
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
+        $extractor = new PropertyInfoExtractor([], [new ReflectionExtractor()]);
+        $objectNormalizer = new ObjectNormalizer($classMetadataFactory, $nameConverter, null, $extractor);
+
+        $signatureProvider = new SignatureProvider(
+            [self::MERCHANT_ID => new PrivateKey(self::FIXTURES . '/test1_private_key.pem')],
+            self::FIXTURES . '/test1_public_key.pem',
+        );
+
+        $serializer = new Serializer(
+            [
+                new ResponseNormalizer($signatureProvider, $objectNormalizer),
+                new RequestNormalizer($objectNormalizer),
+                new CartItemNormalizer($objectNormalizer),
+                new AddressNormalizer($objectNormalizer),
+                new HttpErrorNormalizer(),
+                new EnumNormalizer(),
+                new DateTimeNormalizer(),
+                $objectNormalizer,
+            ],
+            [new JsonEncoder()],
+        );
+
+        $objectNormalizer->setSerializer($serializer);
+
+        $services = [
+            'KHTools\VPos\VPosClient::getSignatureProvider' => $signatureProvider,
+            'KHTools\VPos\VPosClient::getNormalizer'        => $serializer,
+            'KHTools\VPos\VPosClient::getDenormalizer'      => $serializer,
+            'KHTools\VPos\VPosClient::getSerializer'        => $serializer,
+            'KHTools\VPos\VPosClient::getHttpClient'        => $psr18,
+            'KHTools\VPos\VPosClient::getRequestFactory'    => $psr18,
+            'KHTools\VPos\VPosClient::getStreamFactory'     => $psr18,
+        ];
+
+        $container = new class($services) implements ContainerInterface {
+            public function __construct(private array $services) {}
+            public function get(string $id): mixed { return $this->services[$id]; }
+            public function has(string $id): bool { return isset($this->services[$id]); }
+        };
+
+        $client = new VPosClient(VPosClient::VERSION_REST_V1);
+        $client->setContainer($container);
+
+        return [$client, $mockHttpClient];
+    }
+
+    public function testSendPostRequestDeserializesResponse(): void
+    {
+        // JSON does not include 'signature' — ResponseNormalizer skips verification when absent
+        $responseJson = json_encode([
+            'payId'         => 'abc123',
+            'dttm'          => '20240101120000',
+            'resultCode'    => 0,
+            'resultMessage' => 'OK',
+            'paymentStatus' => 1,
+        ]);
+
+        [$client] = $this->buildClient(new MockResponse($responseJson, ['http_code' => 200]));
+
+        $request = new PaymentInitRequest();
+        $request->setMerchant($this->merchant());
+        $request->setOrderNumber('order001');
+        $request->setTotalAmount(1000);
+        $request->setCurrency(Currency::HUF);
+        $request->setReturnUrl('https://example.com/return');
+        $request->setReturnMethod(HttpMethod::Post);
+
+        $response = $client->send($request);
+
+        $this->assertInstanceOf(PaymentInitResponse::class, $response);
+        $this->assertSame('abc123', $response->getPaymentId());
+        $this->assertSame(0, $response->getResultCode());
+        $this->assertSame('OK', $response->getResultMessage());
+        $this->assertSame(1, $response->getPaymentStatus());
+    }
+
+    public function testSendGetRequestBuildsCorrectUrl(): void
+    {
+        $responseJson = json_encode([
+            'payId'         => 'pay001',
+            'dttm'          => '20240101120000',
+            'resultCode'    => 0,
+            'resultMessage' => 'OK',
+            'paymentStatus' => 4,
+        ]);
+
+        $capturedResponse = new MockResponse($responseJson, ['http_code' => 200]);
+        [$client] = $this->buildClient($capturedResponse);
+
+        $request = new PaymentStatusRequest();
+        $request->setMerchant($this->merchant());
+        $request->setPaymentId('pay001');
+
+        $client->send($request);
+
+        $url = $capturedResponse->getRequestUrl();
+        $this->assertStringContainsString('pay001', $url);
+        $this->assertStringContainsString(self::MERCHANT_ID, $url);
+        // Signature must be URL-encoded in GET path (no raw '+' sign)
+        $signatureSegment = explode('/', $url);
+        $rawSignature = array_pop($signatureSegment);
+        $this->assertStringNotContainsString('+', $rawSignature);
+    }
+
+    public function testSendThrowsClientErrorExceptionOnHttp400(): void
+    {
+        $responseJson = json_encode([
+            'resultCode'    => 400,
+            'resultMessage' => 'Bad Request',
+        ]);
+
+        [$client] = $this->buildClient(new MockResponse($responseJson, ['http_code' => 400]));
+
+        $request = new PaymentStatusRequest();
+        $request->setMerchant($this->merchant());
+        $request->setPaymentId('pay001');
+
+        $this->expectException(ClientErrorException::class);
+        $client->send($request);
+    }
+
+    public function testGetPaymentUrlContainsPayIdAndMerchantId(): void
+    {
+        [$client] = $this->buildClient();
+
+        $request = new PaymentProcessRequest();
+        $request->setMerchant($this->merchant());
+        $request->setPaymentId('pay999');
+
+        $url = $client->getPaymentUrlWithPaymentProcessRequest($request);
+
+        $this->assertStringStartsWith('https://api.khpos.hu/api/v1.0/payment/process/', $url);
+        $this->assertStringContainsString('pay999', $url);
+        $this->assertStringContainsString(self::MERCHANT_ID, $url);
+    }
+
+    public function testGetPaymentUrlUsesSandboxWhenTestModeEnabled(): void
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
+        $extractor = new PropertyInfoExtractor([], [new ReflectionExtractor()]);
+        $objectNormalizer = new ObjectNormalizer($classMetadataFactory, $nameConverter, null, $extractor);
+
+        $signatureProvider = new SignatureProvider(
+            [self::MERCHANT_ID => new PrivateKey(self::FIXTURES . '/test1_private_key.pem')],
+            self::FIXTURES . '/test1_public_key.pem',
+        );
+
+        $serializer = new Serializer(
+            [new RequestNormalizer($objectNormalizer), new EnumNormalizer(), $objectNormalizer],
+            [new JsonEncoder()],
+        );
+
+        $psr18 = new Psr18Client(new MockHttpClient());
+        $services = [
+            'KHTools\VPos\VPosClient::getSignatureProvider' => $signatureProvider,
+            'KHTools\VPos\VPosClient::getNormalizer'        => $serializer,
+            'KHTools\VPos\VPosClient::getDenormalizer'      => $serializer,
+            'KHTools\VPos\VPosClient::getSerializer'        => $serializer,
+            'KHTools\VPos\VPosClient::getHttpClient'        => $psr18,
+            'KHTools\VPos\VPosClient::getRequestFactory'    => $psr18,
+            'KHTools\VPos\VPosClient::getStreamFactory'     => $psr18,
+        ];
+
+        $container = new class($services) implements ContainerInterface {
+            public function __construct(private array $services) {}
+            public function get(string $id): mixed { return $this->services[$id]; }
+            public function has(string $id): bool { return isset($this->services[$id]); }
+        };
+
+        $client = new VPosClient(VPosClient::VERSION_REST_V1, isTest: true);
+        $client->setContainer($container);
+
+        $request = new PaymentProcessRequest();
+        $request->setMerchant($this->merchant());
+        $request->setPaymentId('pay001');
+
+        $url = $client->getPaymentUrlWithPaymentProcessRequest($request);
+
+        $this->assertStringStartsWith('https://api.sandbox.khpos.hu/api/v1.0/payment/process/', $url);
+    }
+
+    public function testInitResponseWithArrayDeserializesPaymentStatusResponse(): void
+    {
+        [$client] = $this->buildClient();
+
+        $data = [
+            'payId'         => 'xyz789',
+            'dttm'          => '20240101120000',
+            'resultCode'    => 0,
+            'resultMessage' => 'OK',
+            'paymentStatus' => 4,
+            'authCode'      => 'F7A23E',
+        ];
+
+        $response = $client->initResponseWithArray($data, PaymentStatusResponse::class);
+
+        $this->assertInstanceOf(PaymentStatusResponse::class, $response);
+        $this->assertSame('xyz789', $response->getPaymentId());
+        $this->assertSame(0, $response->getResultCode());
+        $this->assertSame(4, $response->getPaymentStatus());
+        $this->assertSame('F7A23E', $response->getAuthorizationCode());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SignatureProviderTest` — 9 unit tests verifying RSA-SHA256 sign/verify, bool serialization (`true`/`false`), `signature` key exclusion, and nested array flattening
- Add `RequestMetadataTest` — data-driven tests for all 16 request classes (HTTP method, endpoint path, response class implementation)
- Extend `RequestNormalizerTest` and `ResponseNormalizerTest` with `supportsNormalization()` / `supportsDenormalization()` coverage; refactored helpers to eliminate construction duplication
- Add `VPosClientTest` — 6 integration tests wiring real `Serializer` + `SignatureProvider` with `MockHttpClient` + `Psr18Client`; covers POST deserialization, GET URL building, HTTP 400 error, payment URL generation, test-mode sandbox URL, and `initResponseWithArray()`

## Test Plan
- [ ] 197 tests, 295 assertions, 1 intentional skip (PaymentProcessRequest response class — tested separately) — all green
- [ ] No production code changed — tests only

🤖 Generated with [Claude Code](https://claude.com/claude-code)