### PR TITLE
feat: add optional Payum payment processing integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,19 +22,23 @@
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/phpstan-symfony": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "symfony/framework-bundle": "^6.4 || ^7.4"
+        "symfony/framework-bundle": "^6.4 || ^7.4",
+        "payum/core": "^1.7",
+        "payum/payum-bundle": "^2.0"
     },
     "suggest": {
         "symfony/http-kernel": "Required for Symfony bundle integration (^6.4 || ^7.4)",
         "symfony/config": "Required for Symfony bundle integration (^6.4 || ^7.4)",
         "symfony/dependency-injection": "Required for Symfony bundle integration (^6.4 || ^7.4)",
         "symfony/http-client": "Required PSR-18 HTTP client implementation (^6.4 || ^7.4)",
-        "nyholm/psr7": "Required PSR-7 implementation (^1.8)"
+        "nyholm/psr7": "Required PSR-7 implementation (^1.8)",
+        "payum/core": "Payum payment processing integration (^1.7)"
     },
     "autoload": {
         "psr-4": {
             "KHTools\\VPos\\": "src/",
-            "KHTools\\VPos\\Bundle\\": "src/Bundle/"
+            "KHTools\\VPos\\Bundle\\": "src/Bundle/",
+            "KHTools\\VPos\\Payum\\": "src/Payum/"
         }
     },
     "autoload-dev": {

--- a/docs/superpowers/specs/2026-04-11-payum-integration-design.md
+++ b/docs/superpowers/specs/2026-04-11-payum-integration-design.md
@@ -1,0 +1,219 @@
+# Payum Integration — Design Spec
+
+**Date:** 2026-04-11
+
+---
+
+## Goal
+
+Add an optional Payum payment processing integration. Framework-agnostic Actions and a GatewayFactory live in `src/Payum/`; Symfony users get automatic wiring when `payum/payum-bundle` is present, with no extra config required beyond the existing `khvpos:` YAML block.
+
+---
+
+## Approach
+
+Two layers, same package:
+
+1. **`src/Payum/`** — `payum/core`-only dependency. `KHVPosGatewayFactory` + six Action classes wrap `VPosClient`. Works in any PHP environment.
+2. **`src/Bundle/DependencyInjection/Compiler/PayumGatewayPass.php`** — Symfony CompilerPass. Detects `payum/payum-bundle` at container build time and auto-registers the gateway factory and all Actions as services.
+
+`VPosClient` is injected into every Action. Its `ServiceSubscriberTrait` ensures dependencies (HTTP, Serializer, SignatureProvider) are lazy — nothing initialises until the first actual payment operation.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/Payum/KHVPosGatewayFactory.php` | Create | `GatewayFactoryInterface` implementation; builds `VPosClient` + registers Actions |
+| `src/Payum/Constants.php` | Create | K&H `paymentStatus` integer constants with Payum human status mapping |
+| `src/Payum/Action/ConvertPaymentAction.php` | Create | Payum `Payment` model → `PaymentInitRequest` fields |
+| `src/Payum/Action/CaptureAction.php` | Create | `PaymentInit` → `HttpRedirect`; on return calls `PaymentStatus` |
+| `src/Payum/Action/AuthorizeAction.php` | Create | `PaymentInit` URL generation (pre-auth semantics, no money movement yet) |
+| `src/Payum/Action/RefundAction.php` | Create | `PaymentRefundRequest` |
+| `src/Payum/Action/CancelAction.php` | Create | `PaymentReverseRequest` (pending) or `PaymentCloseRequest` (authorized) based on `paymentStatus` |
+| `src/Payum/Action/StatusAction.php` | Create | `PaymentStatusRequest` → `GetHumanStatus` → Payum status constant |
+| `src/Payum/Action/SyncAction.php` | Create | `PaymentStatusRequest` after notify callback |
+| `src/Bundle/DependencyInjection/Compiler/PayumGatewayPass.php` | Create | CompilerPass: detects payum-bundle, registers gateway factory + action services |
+| `tests/Tests/Payum/KHVPosGatewayFactoryTest.php` | Create | Standalone factory creation and gateway build |
+| `tests/Tests/Payum/Action/CaptureActionTest.php` | Create | HttpRedirect thrown, PaymentStatus called on return |
+| `tests/Tests/Payum/Action/AuthorizeActionTest.php` | Create | PaymentInit called, URL stored |
+| `tests/Tests/Payum/Action/RefundActionTest.php` | Create | PaymentRefundRequest dispatched |
+| `tests/Tests/Payum/Action/CancelActionTest.php` | Create | Correct cancel request chosen based on paymentStatus |
+| `tests/Tests/Payum/Action/StatusActionTest.php` | Create | resultCode/paymentStatus → Payum status mapping |
+| `tests/Tests/Payum/Action/SyncActionTest.php` | Create | PaymentStatus called, payment model updated |
+| `tests/Tests/Bundle/PayumGatewayPassTest.php` | Create | CompilerPass registers correct service IDs and tags |
+
+---
+
+## GatewayFactory
+
+`KHVPosGatewayFactory` implements `Payum\Core\GatewayFactoryInterface`.
+
+`create(array $config, Gateway $gateway)` accepts:
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `merchant_id` | string | required | K&H merchant ID |
+| `private_key_path` | string | required | Path to RSA private key PEM |
+| `private_key_passphrase` | string | `''` | Optional passphrase |
+| `mips_public_key_path` | string | `null` | MIPS public key path; `null` = use bundled key |
+| `is_test` | bool | `false` | Use sandbox endpoint |
+| `api_version` | string | `VPosClient::VERSION_REST_V1` | API version constant |
+
+The factory builds an anonymous PSR container (same pattern as `VPosClientTest`), wires a `SignatureProvider` and full `Serializer` stack, and calls `setContainer()` on a new `VPosClient`. All six Actions are added to the `Gateway` via `addAction()`.
+
+---
+
+## Actions
+
+### `ConvertPaymentAction`
+
+Handles `Convert` with `Payment` as first model. Maps Payum's generic payment model to the `PaymentInitRequest`:
+
+- `getNumber()` → `setOrderNumber()`
+- `getTotalAmount()` (in minor units, Payum convention) → `setTotalAmount()`
+- `getCurrencyCode()` → `setCurrency()` (via `Currency` enum)
+- `getDetails()['return_url']` → `setReturnUrl()`
+- `getDetails()['return_method']` → `setReturnMethod()` (default POST)
+
+### `CaptureAction`
+
+Handles `Capture` with `ArrayAccess` model.
+
+**First pass (no `payId` stored yet):**
+1. Builds `PaymentInitRequest` from model details
+2. Calls `$client->send($request)` → receives `PaymentInitResponse`
+3. Stores `payId` and `dttm` in model
+4. Throws `HttpRedirect` with URL from `$client->getPaymentUrlWithPaymentProcessRequest()`
+
+**Second pass (after bank redirect, `payId` present):**
+1. Calls `PaymentStatusRequest` with stored `payId`
+2. Stores full `PaymentStatusResponse` details in model
+3. Returns — Payum proceeds to `StatusAction`
+
+### `AuthorizeAction`
+
+Handles `Authorize` with `ArrayAccess` model.
+
+Same as CaptureAction first pass, but stores the redirect URL in `model['authorization_url']` instead of throwing `HttpRedirect`. Caller is responsible for presenting the URL. Useful for deferred payment flows.
+
+### `StatusAction`
+
+Handles `GetHumanStatus`. Reads `model['resultCode']` and `model['paymentStatus']`.
+
+**Mapping:**
+
+| Condition | Payum status |
+|---|---|
+| No `payId` stored | `new` |
+| `resultCode = 0`, `paymentStatus` ∈ {1, 2} | `pending` |
+| `resultCode = 150` | `pending` (3DS in progress) |
+| `resultCode = 0`, `paymentStatus = 4` | `captured` |
+| `resultCode = 0`, `paymentStatus` ∈ {6, 7, 8} | `canceled` |
+| `resultCode = 0`, `paymentStatus` ∈ {3, 5} | `authorized` |
+| `resultCode > 0` (other) | `failed` |
+
+### `RefundAction`
+
+Handles `Refund`. Reads `model['payId']` and `model['refund_amount']` (full amount if absent). Calls `PaymentRefundRequest`. Stores `resultCode` and `resultMessage` back into model.
+
+### `CancelAction`
+
+Handles `Cancel`. Reads `model['paymentStatus']`:
+- Status `1` or `2` (pending, not yet authorized) → `PaymentReverseRequest`
+- Status `3` or `5` (authorized, pre-capture) → `PaymentCloseRequest`
+- Status `4` (already captured) → throws `\LogicException` (use `RefundAction` instead)
+
+Stores result in model.
+
+### `SyncAction`
+
+Handles `Sync`. Calls `PaymentStatusRequest` with `model['payId']`. Updates model with fresh `paymentStatus`, `resultCode`, `resultMessage`. Used after IPN/notify callback.
+
+---
+
+## Bundle Auto-Wiring
+
+### `PayumGatewayPass`
+
+Implements `CompilerPassInterface`. Registered in `KHVPosBundle::build()`.
+
+```php
+public function process(ContainerBuilder $container): void
+{
+    if (!$container->hasDefinition('payum')) {
+        return;
+    }
+    // Register KHVPosGatewayFactory as a Payum gateway factory
+    // Tag: payum.gateway_factory, factory_name: khvpos, factory_alias: khvpos
+    // Register each Action service with tag: payum.action, factory: khvpos
+    // Wire khvpos.vpos_client as argument to all Action definitions
+}
+```
+
+If `payum` service is not in the container (i.e. `payum/payum-bundle` is not installed), the pass is a no-op.
+
+### Result in Symfony
+
+With `payum/payum-bundle` installed, no additional YAML is needed. The `khvpos:` config block is sufficient:
+
+```yaml
+khvpos:
+    test: false
+    merchants:
+        default:
+            currency: HUF
+            merchant_id: 'M123456789'
+            private_key_path: '%kernel.project_dir%/config/keys/merchant.pem'
+```
+
+A `khvpos` Payum gateway is automatically available:
+
+```php
+$gateway = $payum->getGateway('khvpos');
+$gateway->execute(new Capture($payment));
+```
+
+### `composer.json` changes
+
+Add to `suggest`:
+```json
+"payum/core": "Payum payment processing integration (^2.0)"
+```
+
+Add to `require-dev`:
+```json
+"payum/payum-bundle": "^2.0"
+```
+
+Add to `autoload`:
+```json
+"KHTools\\VPos\\Payum\\": "src/Payum/"
+```
+
+---
+
+## Tests
+
+All tests are unit tests with mocked `VPosClient`.
+
+**Action tests** (one file per Action): mock `VPosClient::send()` return value, assert:
+- Correct request class passed to `send()`
+- Correct fields set on request
+- Correct Payum response thrown or returned
+- Model updated with correct keys
+
+**`KHVPosGatewayFactoryTest`**: call `create()` with minimal config, assert `Gateway` contains all six Action instances.
+
+**`PayumGatewayPassTest`**: mock `ContainerBuilder` with a `payum` definition present; assert factory and action service definitions are registered with correct tags.
+
+**CI:** No new workflow needed. `payum/payum-bundle` added to `require-dev` runs in the existing `tests.yml` matrix (PHP 8.4, 8.5).
+
+---
+
+## Out of Scope
+
+- Payum storage integration (tokens, payments persistence) — Payum's generic storage layer handles this; no KH-specific code needed
+- Notify/webhook endpoint — Payum's `NotifyAction` base handles routing; `SyncAction` handles the VPos status refresh
+- One-click / Apple Pay / Google Pay Payum Actions — these use different Payum request types and can be a follow-up

--- a/src/Bundle/DependencyInjection/Compiler/PayumGatewayPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/PayumGatewayPass.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Bundle\DependencyInjection\Compiler;
+
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Payum\Action\AuthorizeAction;
+use KHTools\VPos\Payum\Action\CancelAction;
+use KHTools\VPos\Payum\Action\CaptureAction;
+use KHTools\VPos\Payum\Action\ConvertPaymentAction;
+use KHTools\VPos\Payum\Action\RefundAction;
+use KHTools\VPos\Payum\Action\StatusAction;
+use KHTools\VPos\Payum\Action\SyncAction;
+use KHTools\VPos\Payum\KHVPosGatewayFactory;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class PayumGatewayPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('payum')) {
+            return;
+        }
+
+        $config = $container->getParameter('khvpos.client_provider.config');
+        if (empty($config['merchants'][0]['merchant_id'])) {
+            throw new \LogicException(
+                'PayumGatewayPass requires at least one merchant with a non-empty merchant_id in khvpos.client_provider.config. '
+                . 'Note: multi-merchant Payum integration is not yet supported; only the first merchant is used.'
+            );
+        }
+        $merchantId = $config['merchants'][0]['merchant_id'];
+        // Only the first merchant is wired into Payum actions. Multi-merchant support
+        // (selecting merchant by currency etc.) is not yet implemented for Payum.
+
+        // Register the gateway factory
+        $factoryDef = new Definition(KHVPosGatewayFactory::class);
+        $factoryDef->addTag('payum.gateway_factory', [
+            'factory_name'  => 'khvpos',
+            'factory_title' => 'K&H VPos',
+        ]);
+        $container->setDefinition('khvpos.payum.gateway_factory', $factoryDef);
+
+        $vposClientRef = new Reference('khvpos.vpos_client');
+
+        $merchantDef = new Definition(Merchant::class);
+        $merchantDef->addMethodCall('setMerchantId', [$merchantId]);
+        $container->setDefinition('khvpos.payum.merchant', $merchantDef);
+        $merchantRef = new Reference('khvpos.payum.merchant');
+
+        // Actions that need VPosClient + Merchant
+        foreach ([
+            'khvpos.payum.action.capture'   => CaptureAction::class,
+            'khvpos.payum.action.authorize'  => AuthorizeAction::class,
+            'khvpos.payum.action.refund'     => RefundAction::class,
+            'khvpos.payum.action.cancel'     => CancelAction::class,
+            'khvpos.payum.action.sync'       => SyncAction::class,
+        ] as $serviceId => $class) {
+            $def = new Definition($class, [$vposClientRef, $merchantRef]);
+            $def->addTag('payum.action', ['factory' => 'khvpos']);
+            $container->setDefinition($serviceId, $def);
+        }
+
+        // Actions with no dependencies
+        foreach ([
+            'khvpos.payum.action.convert' => ConvertPaymentAction::class,
+            'khvpos.payum.action.status'  => StatusAction::class,
+        ] as $serviceId => $class) {
+            $def = new Definition($class);
+            $def->addTag('payum.action', ['factory' => 'khvpos']);
+            $container->setDefinition($serviceId, $def);
+        }
+    }
+}

--- a/src/Bundle/DependencyInjection/Compiler/PayumGatewayPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/PayumGatewayPass.php
@@ -25,7 +25,7 @@ class PayumGatewayPass implements CompilerPassInterface
         }
 
         $config = $container->getParameter('khvpos.client_provider.config');
-        if (empty($config['merchants'][0]['merchant_id'])) {
+        if (!isset($config['merchants'][0]['merchant_id']) || $config['merchants'][0]['merchant_id'] === '') {
             throw new \LogicException(
                 'PayumGatewayPass requires at least one merchant with a non-empty merchant_id in khvpos.client_provider.config. '
                 . 'Note: multi-merchant Payum integration is not yet supported; only the first merchant is used.'

--- a/src/Bundle/KHVPosBundle.php
+++ b/src/Bundle/KHVPosBundle.php
@@ -2,7 +2,9 @@
 
 namespace KHTools\VPos\Bundle;
 
+use KHTools\VPos\Bundle\DependencyInjection\Compiler\PayumGatewayPass;
 use KHTools\VPos\Bundle\DependencyInjection\PaymentGatewayExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -11,5 +13,11 @@ class KHVPosBundle extends Bundle
     public function getContainerExtension(): ?ExtensionInterface
     {
         return new PaymentGatewayExtension();
+    }
+
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+        $container->addCompilerPass(new PayumGatewayPass());
     }
 }

--- a/src/Payum/Action/AuthorizeAction.php
+++ b/src/Payum/Action/AuthorizeAction.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Payum\Action;
+
+use KHTools\VPos\Models\Enums\Currency;
+use KHTools\VPos\Models\Enums\HttpMethod;
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Requests\PaymentInitRequest;
+use KHTools\VPos\Requests\PaymentProcessRequest;
+use KHTools\VPos\VPosClient;
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Request\Authorize;
+
+class AuthorizeAction implements ActionInterface
+{
+    public function __construct(
+        private readonly VPosClient $client,
+        private readonly Merchant $merchant,
+    ) {}
+
+    public function execute($request): void
+    {
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        $model = ArrayObject::ensureArrayObject($request->getModel());
+
+        if (isset($model['payId'])) {
+            return; // already initialised
+        }
+
+        $initRequest = new PaymentInitRequest();
+        $initRequest->setMerchant($this->merchant);
+        $initRequest->setOrderNumber((string) $model['order_number']);
+        $initRequest->setTotalAmount((float) ($model['total_amount'] / 100));
+        $initRequest->setCurrency(Currency::initWithString((string) $model['currency']));
+        $initRequest->setReturnUrl((string) $model['return_url']);
+        $initRequest->setReturnMethod(HttpMethod::initWithString((string) ($model['return_method'] ?? 'POST')));
+
+        $initResponse = $this->client->send($initRequest);
+
+        $model['payId'] = $initResponse->getPaymentId();
+        $model['paymentStatus'] = $initResponse->getPaymentStatus();
+        $model['resultCode'] = $initResponse->getResultCode();
+        $model['resultMessage'] = $initResponse->getResultMessage();
+
+        $processRequest = PaymentProcessRequest::initWith($initResponse, $this->merchant);
+        $model['authorization_url'] = $this->client->getPaymentUrlWithPaymentProcessRequest($processRequest);
+    }
+
+    public function supports($request): bool
+    {
+        return $request instanceof Authorize
+            && $request->getModel() instanceof \ArrayAccess;
+    }
+}

--- a/src/Payum/Action/CancelAction.php
+++ b/src/Payum/Action/CancelAction.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Payum\Action;
+
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Payum\Constants;
+use KHTools\VPos\Requests\PaymentCloseRequest;
+use KHTools\VPos\Requests\PaymentReverseRequest;
+use KHTools\VPos\VPosClient;
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Request\Cancel;
+
+class CancelAction implements ActionInterface
+{
+    public function __construct(
+        private readonly VPosClient $client,
+        private readonly Merchant $merchant,
+    ) {}
+
+    public function execute($request): void
+    {
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        $model = ArrayObject::ensureArrayObject($request->getModel());
+        $paymentStatus = (int) ($model['paymentStatus'] ?? 0);
+        $payId = (string) $model['payId'];
+
+        if ($payId === '') {
+            throw new \LogicException('Cannot cancel payment: "payId" is not set in the model.');
+        }
+
+        if (in_array($paymentStatus, [Constants::STATUS_PENDING, Constants::STATUS_PROCESSING], true)) {
+            $reverseRequest = new PaymentReverseRequest();
+            $reverseRequest->setMerchant($this->merchant);
+            $reverseRequest->setPaymentId($payId);
+            $response = $this->client->send($reverseRequest);
+        } elseif (in_array($paymentStatus, [Constants::STATUS_CANCELLED, Constants::STATUS_AUTHORIZED], true)) {
+            $closeRequest = new PaymentCloseRequest();
+            $closeRequest->setMerchant($this->merchant);
+            $closeRequest->setPaymentId($payId);
+            $response = $this->client->send($closeRequest);
+        } elseif ($paymentStatus === Constants::STATUS_CONFIRMED) {
+            throw new \LogicException(sprintf(
+                'Cannot cancel payment "%s" with status %d (already captured). Use RefundAction instead.',
+                $payId,
+                $paymentStatus,
+            ));
+        } else {
+            return; // already cancelled/reversed/closed — no-op
+        }
+
+        $model['resultCode'] = $response->getResultCode();
+        $model['resultMessage'] = $response->getResultMessage();
+    }
+
+    public function supports($request): bool
+    {
+        return $request instanceof Cancel
+            && $request->getModel() instanceof \ArrayAccess;
+    }
+}

--- a/src/Payum/Action/CaptureAction.php
+++ b/src/Payum/Action/CaptureAction.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Payum\Action;
+
+use KHTools\VPos\Models\Enums\Currency;
+use KHTools\VPos\Models\Enums\HttpMethod;
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Requests\PaymentInitRequest;
+use KHTools\VPos\Requests\PaymentProcessRequest;
+use KHTools\VPos\Requests\PaymentStatusRequest;
+use KHTools\VPos\VPosClient;
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Reply\HttpRedirect;
+use Payum\Core\Request\Capture;
+
+class CaptureAction implements ActionInterface
+{
+    public function __construct(
+        private readonly VPosClient $client,
+        private readonly Merchant $merchant,
+    ) {}
+
+    public function execute($request): void
+    {
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        $model = ArrayObject::ensureArrayObject($request->getModel());
+
+        if (!isset($model['payId'])) {
+            $this->initPayment($model);
+        } else {
+            $this->refreshStatus($model);
+        }
+    }
+
+    private function initPayment(ArrayObject $model): never
+    {
+        $initRequest = new PaymentInitRequest();
+        $initRequest->setMerchant($this->merchant);
+        $initRequest->setOrderNumber((string) $model['order_number']);
+        $initRequest->setTotalAmount((float) ($model['total_amount'] / 100));
+        $initRequest->setCurrency(Currency::initWithString((string) $model['currency']));
+        $initRequest->setReturnUrl((string) $model['return_url']);
+        $initRequest->setReturnMethod(HttpMethod::initWithString((string) ($model['return_method'] ?? 'POST')));
+
+        $initResponse = $this->client->send($initRequest);
+
+        $model['payId'] = $initResponse->getPaymentId();
+        $model['paymentStatus'] = $initResponse->getPaymentStatus();
+        $model['resultCode'] = $initResponse->getResultCode();
+        $model['resultMessage'] = $initResponse->getResultMessage();
+
+        $processRequest = PaymentProcessRequest::initWith($initResponse, $this->merchant);
+        $url = $this->client->getPaymentUrlWithPaymentProcessRequest($processRequest);
+
+        throw new HttpRedirect($url);
+    }
+
+    private function refreshStatus(ArrayObject $model): void
+    {
+        $statusRequest = new PaymentStatusRequest();
+        $statusRequest->setMerchant($this->merchant);
+        $statusRequest->setPaymentId((string) $model['payId']);
+
+        $statusResponse = $this->client->send($statusRequest);
+
+        $model['resultCode']    = $statusResponse->getResultCode();
+        $model['paymentStatus'] = $statusResponse->getPaymentStatus() ?? $model['paymentStatus'];
+        $model['resultMessage'] = $statusResponse->getResultMessage();
+    }
+
+    public function supports($request): bool
+    {
+        return $request instanceof Capture
+            && $request->getModel() instanceof \ArrayAccess;
+    }
+}

--- a/src/Payum/Action/ConvertPaymentAction.php
+++ b/src/Payum/Action/ConvertPaymentAction.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Payum\Action;
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Model\PaymentInterface;
+use Payum\Core\Request\Convert;
+
+class ConvertPaymentAction implements ActionInterface
+{
+    public function execute($request): void
+    {
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        /** @var PaymentInterface $payment */
+        $payment = $request->getSource();
+        $details = ArrayObject::ensureArrayObject($payment->getDetails());
+
+        $details['order_number'] = $payment->getNumber();
+        $details['total_amount'] = $payment->getTotalAmount();
+        $details['currency']     = $payment->getCurrencyCode();
+        // return_url is required by PaymentInitRequest; an empty string will fail at the gateway layer
+        $details['return_url']    = $details['return_url'] ?? '';
+        $details['return_method'] = $details['return_method'] ?? 'POST';
+        $details['merchant_id']   = $details['merchant_id'] ?? null;
+
+        $request->setResult((array) $details);
+    }
+
+    public function supports($request): bool
+    {
+        return $request instanceof Convert
+            && $request->getSource() instanceof PaymentInterface
+            && $request->getTo() === 'array';
+    }
+}

--- a/src/Payum/Action/RefundAction.php
+++ b/src/Payum/Action/RefundAction.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Payum\Action;
+
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Requests\PaymentRefundRequest;
+use KHTools\VPos\VPosClient;
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Request\Refund;
+
+class RefundAction implements ActionInterface
+{
+    public function __construct(
+        private readonly VPosClient $client,
+        private readonly Merchant $merchant,
+    ) {}
+
+    public function execute($request): void
+    {
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        $model = ArrayObject::ensureArrayObject($request->getModel());
+
+        $refundRequest = new PaymentRefundRequest();
+        $refundRequest->setMerchant($this->merchant);
+        $refundRequest->setPaymentId((string) $model['payId']);
+
+        if (isset($model['refund_amount'])) {
+            // refund_amount is stored in minor units (fillér); setAmount expects float HUF
+            $refundRequest->setAmount((float) bcdiv((string) ((int) $model['refund_amount']), '100', 2));
+        }
+
+        $response = $this->client->send($refundRequest);
+
+        $model['resultCode'] = $response->getResultCode();
+        $model['resultMessage'] = $response->getResultMessage();
+    }
+
+    public function supports($request): bool
+    {
+        return $request instanceof Refund
+            && $request->getModel() instanceof \ArrayAccess;
+    }
+}

--- a/src/Payum/Action/StatusAction.php
+++ b/src/Payum/Action/StatusAction.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Payum\Action;
+
+use KHTools\VPos\Payum\Constants;
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Request\GetHumanStatus;
+
+/**
+ * Maps stored resultCode + paymentStatus model fields to Payum human status.
+ * Does not make API calls — model must be updated first (by CaptureAction or SyncAction).
+ */
+class StatusAction implements ActionInterface
+{
+    public function execute($request): void
+    {
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        $model = ArrayObject::ensureArrayObject($request->getModel());
+
+        if (!isset($model['payId'])) {
+            $request->markNew();
+            return;
+        }
+
+        $resultCode = (int) ($model['resultCode'] ?? -1);
+        $paymentStatus = (int) ($model['paymentStatus'] ?? -1);
+
+        if ($resultCode === Constants::RESULT_3DS_IN_PROGRESS) {
+            $request->markPending();
+            return;
+        }
+
+        if ($resultCode !== Constants::RESULT_OK) {
+            $request->markFailed();
+            return;
+        }
+
+        match ($paymentStatus) {
+            Constants::STATUS_PENDING,
+            Constants::STATUS_PROCESSING    => $request->markPending(),
+            Constants::STATUS_CONFIRMED     => $request->markCaptured(),
+            Constants::STATUS_AUTHORIZED    => $request->markAuthorized(),
+            Constants::STATUS_CANCELLED,
+            Constants::STATUS_REVERSED,
+            Constants::STATUS_CLOSED        => $request->markCanceled(),
+            default                         => $request->markUnknown(),
+        };
+    }
+
+    public function supports($request): bool
+    {
+        return $request instanceof GetHumanStatus
+            && $request->getModel() instanceof \ArrayAccess;
+    }
+}

--- a/src/Payum/Action/SyncAction.php
+++ b/src/Payum/Action/SyncAction.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Payum\Action;
+
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Requests\PaymentStatusRequest;
+use KHTools\VPos\VPosClient;
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Request\Sync;
+
+class SyncAction implements ActionInterface
+{
+    public function __construct(
+        private readonly VPosClient $client,
+        private readonly Merchant $merchant,
+    ) {}
+
+    public function execute($request): void
+    {
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        $model = ArrayObject::ensureArrayObject($request->getModel());
+
+        if (!isset($model['payId'])) {
+            return;
+        }
+
+        $statusRequest = new PaymentStatusRequest();
+        $statusRequest->setMerchant($this->merchant);
+        $statusRequest->setPaymentId($model['payId']);
+
+        $response = $this->client->send($statusRequest);
+
+        $model['resultCode'] = $response->getResultCode();
+        $model['paymentStatus'] = $response->getPaymentStatus();
+        $model['resultMessage'] = $response->getResultMessage();
+    }
+
+    public function supports($request): bool
+    {
+        return $request instanceof Sync
+            && $request->getModel() instanceof \ArrayAccess;
+    }
+}

--- a/src/Payum/Constants.php
+++ b/src/Payum/Constants.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Payum;
+
+final class Constants
+{
+    /** Payment created, waiting for customer action */
+    public const STATUS_PENDING = 1;
+    /** Customer interaction in progress */
+    public const STATUS_PROCESSING = 2;
+    /** Cancelled (by customer or timeout) */
+    public const STATUS_CANCELLED = 3;
+    /** Payment confirmed — money taken */
+    public const STATUS_CONFIRMED = 4;
+    /** Pre-authorized — awaiting close/capture */
+    public const STATUS_AUTHORIZED = 5;
+    /** Rejected by bank */
+    public const STATUS_REJECTED = 6;
+    /** Payment reversed */
+    public const STATUS_REVERSED = 7;
+    /** Payment closed */
+    public const STATUS_CLOSED = 8;
+
+    /** Success */
+    public const RESULT_OK = 0;
+    /** 3DS authentication in progress */
+    public const RESULT_3DS_IN_PROGRESS = 150;
+}

--- a/src/Payum/KHVPosGatewayFactory.php
+++ b/src/Payum/KHVPosGatewayFactory.php
@@ -42,8 +42,8 @@ class KHVPosGatewayFactory implements GatewayFactoryInterface
      * Returns the config as-is; this factory does not use GatewayFactorySupport
      * so config defaults are applied directly in create().
      *
-     * @param array<string, mixed> $config
-     * @return array<string, mixed>
+     * @param array<array-key, mixed> $config
+     * @return array<array-key, mixed>
      */
     public function createConfig(array $config = []): array
     {
@@ -51,22 +51,18 @@ class KHVPosGatewayFactory implements GatewayFactoryInterface
     }
 
     /**
-     * @param array{
-     *     merchant_id: string,
-     *     private_key_path: string,
-     *     private_key_passphrase?: string|null,
-     *     mips_public_key_path?: string|null,
-     *     is_test?: bool,
-     *     api_version?: string,
-     *     http_client?: ClientInterface,
-     * } $config
+     * Supported config keys: merchant_id (string, required), private_key_path (string, required),
+     * private_key_passphrase (string|null), mips_public_key_path (string|null),
+     * is_test (bool), api_version (string), http_client (ClientInterface).
+     *
+     * @param array<array-key, mixed> $config
      */
     public function create(array $config = []): GatewayInterface
     {
-        if (empty($config['merchant_id'])) {
+        if (!isset($config['merchant_id']) || $config['merchant_id'] === '') {
             throw new \InvalidArgumentException('The "merchant_id" config option is required.');
         }
-        if (empty($config['private_key_path'])) {
+        if (!isset($config['private_key_path']) || $config['private_key_path'] === '') {
             throw new \InvalidArgumentException('The "private_key_path" config option is required.');
         }
 
@@ -146,6 +142,7 @@ class KHVPosGatewayFactory implements GatewayFactoryInterface
         ];
 
         $container = new class($services) implements ContainerInterface {
+            /** @param array<string, mixed> $services */
             public function __construct(private readonly array $services) {}
             public function get(string $id): mixed { return $this->services[$id]; }
             public function has(string $id): bool { return isset($this->services[$id]); }

--- a/src/Payum/KHVPosGatewayFactory.php
+++ b/src/Payum/KHVPosGatewayFactory.php
@@ -1,0 +1,171 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\VPos\Payum;
+
+use KHTools\VPos\Keys\PrivateKey;
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Normalizers\AddressNormalizer;
+use KHTools\VPos\Normalizers\CartItemNormalizer;
+use KHTools\VPos\Normalizers\EnumNormalizer;
+use KHTools\VPos\Normalizers\HttpErrorNormalizer;
+use KHTools\VPos\Normalizers\RequestNormalizer;
+use KHTools\VPos\Normalizers\ResponseNormalizer;
+use KHTools\VPos\Payum\Action\AuthorizeAction;
+use KHTools\VPos\Payum\Action\CancelAction;
+use KHTools\VPos\Payum\Action\CaptureAction;
+use KHTools\VPos\Payum\Action\ConvertPaymentAction;
+use KHTools\VPos\Payum\Action\RefundAction;
+use KHTools\VPos\Payum\Action\StatusAction;
+use KHTools\VPos\Payum\Action\SyncAction;
+use KHTools\VPos\SignatureProvider;
+use KHTools\VPos\VPosClient;
+use Payum\Core\Gateway;
+use Payum\Core\GatewayFactoryInterface;
+use Payum\Core\GatewayInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Client\ClientInterface;
+use Symfony\Component\HttpClient\NativeHttpClient;
+use Symfony\Component\HttpClient\Psr18Client;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
+use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+class KHVPosGatewayFactory implements GatewayFactoryInterface
+{
+    /**
+     * Returns the config as-is; this factory does not use GatewayFactorySupport
+     * so config defaults are applied directly in create().
+     *
+     * @param array<string, mixed> $config
+     * @return array<string, mixed>
+     */
+    public function createConfig(array $config = []): array
+    {
+        return $config;
+    }
+
+    /**
+     * @param array{
+     *     merchant_id: string,
+     *     private_key_path: string,
+     *     private_key_passphrase?: string|null,
+     *     mips_public_key_path?: string|null,
+     *     is_test?: bool,
+     *     api_version?: string,
+     *     http_client?: ClientInterface,
+     * } $config
+     */
+    public function create(array $config = []): GatewayInterface
+    {
+        if (empty($config['merchant_id'])) {
+            throw new \InvalidArgumentException('The "merchant_id" config option is required.');
+        }
+        if (empty($config['private_key_path'])) {
+            throw new \InvalidArgumentException('The "private_key_path" config option is required.');
+        }
+
+        $client = $this->buildVPosClient($config);
+
+        $merchant = new Merchant();
+        $merchant->merchantId = $config['merchant_id'];
+
+        $gateway = new Gateway();
+        $gateway->addAction(new ConvertPaymentAction());
+        $gateway->addAction(new CaptureAction($client, $merchant));
+        $gateway->addAction(new AuthorizeAction($client, $merchant));
+        $gateway->addAction(new StatusAction());
+        $gateway->addAction(new RefundAction($client, $merchant));
+        $gateway->addAction(new CancelAction($client, $merchant));
+        $gateway->addAction(new SyncAction($client, $merchant));
+
+        return $gateway;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function buildVPosClient(array $config): VPosClient
+    {
+        if (isset($config['http_client'])) {
+            $psr18 = $config['http_client'];
+        } else {
+            if (!class_exists(NativeHttpClient::class)) {
+                throw new \RuntimeException(
+                    'Install symfony/http-client or pass an "http_client" (PSR-18) in the factory config.'
+                );
+            }
+            $psr18 = new Psr18Client(new NativeHttpClient());
+        }
+
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
+        $extractor = new PropertyInfoExtractor([], [new ReflectionExtractor()]);
+        $objectNormalizer = new ObjectNormalizer($classMetadataFactory, $nameConverter, null, $extractor);
+
+        $mipsPublicKeyPath = $config['mips_public_key_path'] ?? $this->getBundledMipsPublicKeyPath(
+            (bool) ($config['is_test'] ?? false)
+        );
+
+        $signatureProvider = new SignatureProvider(
+            [$config['merchant_id'] => new PrivateKey(
+                $config['private_key_path'],
+                $config['private_key_passphrase'] ?? null,
+            )],
+            $mipsPublicKeyPath,
+        );
+
+        $serializer = new Serializer(
+            [
+                new ResponseNormalizer($signatureProvider, $objectNormalizer),
+                new RequestNormalizer($objectNormalizer),
+                new CartItemNormalizer($objectNormalizer),
+                new AddressNormalizer($objectNormalizer),
+                new HttpErrorNormalizer(),
+                new EnumNormalizer(),
+                new DateTimeNormalizer(),
+                $objectNormalizer,
+            ],
+            [new JsonEncoder()],
+        );
+        $objectNormalizer->setSerializer($serializer);
+
+        $services = [
+            'KHTools\VPos\VPosClient::getSignatureProvider' => $signatureProvider,
+            'KHTools\VPos\VPosClient::getNormalizer'        => $serializer,
+            'KHTools\VPos\VPosClient::getDenormalizer'      => $serializer,
+            'KHTools\VPos\VPosClient::getSerializer'        => $serializer,
+            'KHTools\VPos\VPosClient::getHttpClient'        => $psr18,
+            'KHTools\VPos\VPosClient::getRequestFactory'    => $psr18,
+            'KHTools\VPos\VPosClient::getStreamFactory'     => $psr18,
+        ];
+
+        $container = new class($services) implements ContainerInterface {
+            public function __construct(private readonly array $services) {}
+            public function get(string $id): mixed { return $this->services[$id]; }
+            public function has(string $id): bool { return isset($this->services[$id]); }
+        };
+
+        $vposClient = new VPosClient(
+            $config['api_version'] ?? VPosClient::VERSION_REST_V1,
+            (bool) ($config['is_test'] ?? false),
+        );
+        $vposClient->setContainer($container);
+
+        return $vposClient;
+    }
+
+    private function getBundledMipsPublicKeyPath(bool $sandbox): string
+    {
+        return sprintf(
+            '%s/../Bundle/Resources/keys/mips_pay%s.khpos.hu.pub',
+            __DIR__,
+            $sandbox ? '.sandbox' : '',
+        );
+    }
+}

--- a/src/Requests/ApplePayEchoRequest.php
+++ b/src/Requests/ApplePayEchoRequest.php
@@ -10,6 +10,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
+/** @implements RequestInterface<ApplePayEchoResponse> */
 class ApplePayEchoRequest implements RequestInterface
 {
 	use MerchantTrait;

--- a/src/Requests/ApplePayInitRequest.php
+++ b/src/Requests/ApplePayInitRequest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 
+/** @implements RequestInterface<ApplePayInitResponse> */
 class ApplePayInitRequest implements RequestInterface
 {
 	use MerchantTrait;

--- a/src/Requests/ApplePayProcessRequest.php
+++ b/src/Requests/ApplePayProcessRequest.php
@@ -12,6 +12,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
+/** @implements RequestInterface<ApplePayProcessResponse> */
 class ApplePayProcessRequest implements RequestInterface
 {
 	use MerchantTrait;

--- a/src/Requests/EchoRequest.php
+++ b/src/Requests/EchoRequest.php
@@ -8,6 +8,7 @@ use KHTools\VPos\Responses\EchoResponse;
 use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 
+/** @implements RequestInterface<EchoResponse> */
 class EchoRequest implements RequestInterface
 {
     use MerchantTrait;

--- a/src/Requests/GooglePayEchoRequest.php
+++ b/src/Requests/GooglePayEchoRequest.php
@@ -10,6 +10,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
+/** @implements RequestInterface<GooglePayEchoResponse> */
 class GooglePayEchoRequest implements RequestInterface
 {
 	use MerchantTrait;

--- a/src/Requests/GooglePayInitRequest.php
+++ b/src/Requests/GooglePayInitRequest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 
+/** @implements RequestInterface<GooglePayInitResponse> */
 class GooglePayInitRequest implements RequestInterface
 {
 	use MerchantTrait;

--- a/src/Requests/GooglePayProcessRequest.php
+++ b/src/Requests/GooglePayProcessRequest.php
@@ -12,6 +12,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
+/** @implements RequestInterface<GooglePayProcessResponse> */
 class GooglePayProcessRequest implements RequestInterface
 {
 	use MerchantTrait;

--- a/src/Requests/OneClickEchoRequest.php
+++ b/src/Requests/OneClickEchoRequest.php
@@ -11,6 +11,7 @@ use Symfony\Component\Serializer\Annotation\SerializedName;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
+/** @implements RequestInterface<OneClickEchoResponse> */
 class OneClickEchoRequest implements RequestInterface
 {
 	use MerchantTrait;

--- a/src/Requests/OneClickInitRequest.php
+++ b/src/Requests/OneClickInitRequest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 
+/** @implements RequestInterface<OneClickInitResponse> */
 class OneClickInitRequest implements RequestInterface
 {
 	use MerchantTrait;

--- a/src/Requests/OneClickProcessRequest.php
+++ b/src/Requests/OneClickProcessRequest.php
@@ -12,6 +12,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
+/** @implements RequestInterface<OneClickProcessResponse> */
 class OneClickProcessRequest implements RequestInterface
 {
 	use MerchantTrait;

--- a/src/Requests/PaymentCloseRequest.php
+++ b/src/Requests/PaymentCloseRequest.php
@@ -11,6 +11,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
+/** @implements RequestInterface<PaymentCloseResponse> */
 class PaymentCloseRequest implements RequestInterface
 {
     use MerchantTrait;

--- a/src/Requests/PaymentInitRequest.php
+++ b/src/Requests/PaymentInitRequest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 
+/** @implements RequestInterface<PaymentInitResponse> */
 class PaymentInitRequest implements RequestInterface
 {
     use MerchantTrait;

--- a/src/Requests/PaymentProcessRequest.php
+++ b/src/Requests/PaymentProcessRequest.php
@@ -7,10 +7,12 @@ use KHTools\VPos\Normalizers\NormalizerResultOrderingHelper;
 use KHTools\VPos\Requests\Traits\MerchantTrait;
 use KHTools\VPos\Requests\Traits\PaymentIdTrait;
 use KHTools\VPos\Responses\PaymentInitResponse;
+use KHTools\VPos\Responses\ResponseInterface;
 use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
+/** @implements RequestInterface<ResponseInterface> */
 class PaymentProcessRequest implements RequestInterface
 {
     use MerchantTrait;

--- a/src/Requests/PaymentRefundRequest.php
+++ b/src/Requests/PaymentRefundRequest.php
@@ -12,6 +12,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
+/** @implements RequestInterface<PaymentRefundResponse> */
 class PaymentRefundRequest implements RequestInterface
 {
     use MerchantTrait;

--- a/src/Requests/PaymentReverseRequest.php
+++ b/src/Requests/PaymentReverseRequest.php
@@ -11,6 +11,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
+/** @implements RequestInterface<PaymentReverseResponse> */
 class PaymentReverseRequest implements RequestInterface
 {
     use MerchantTrait;

--- a/src/Requests/PaymentStatusRequest.php
+++ b/src/Requests/PaymentStatusRequest.php
@@ -12,6 +12,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
+/** @implements RequestInterface<PaymentStatusResponse> */
 class PaymentStatusRequest implements RequestInterface
 {
     use MerchantTrait;

--- a/src/Requests/RequestInterface.php
+++ b/src/Requests/RequestInterface.php
@@ -4,6 +4,9 @@ namespace KHTools\VPos\Requests;
 
 use KHTools\VPos\Models\Merchant;
 
+/**
+ * @template TResponse of \KHTools\VPos\Responses\ResponseInterface
+ */
 interface RequestInterface
 {
     public function getRequestMethod(): string;
@@ -15,7 +18,7 @@ interface RequestInterface
     public function setMerchant(Merchant $merchant): void;
 
     /**
-     * @return class-string
+     * @return class-string<TResponse>
      */
     public function getResponseClass(): string;
 

--- a/src/VPosClient.php
+++ b/src/VPosClient.php
@@ -63,6 +63,11 @@ class VPosClient implements ServiceSubscriberInterface
         }, $endpointPath);
     }
 
+    /**
+     * @template TResponse of ResponseInterface
+     * @param RequestInterface<TResponse> $request
+     * @return TResponse
+     */
     public function send(RequestInterface $request): ResponseInterface
     {
         $requestParameters = (array) $this->getNormalizer()->normalize($request);

--- a/tests/Tests/Bundle/PayumGatewayPassTest.php
+++ b/tests/Tests/Bundle/PayumGatewayPassTest.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\Tests\Bundle;
+
+use KHTools\VPos\Bundle\DependencyInjection\Compiler\PayumGatewayPass;
+use KHTools\VPos\Payum\Action\AuthorizeAction;
+use KHTools\VPos\Payum\Action\CancelAction;
+use KHTools\VPos\Payum\Action\CaptureAction;
+use KHTools\VPos\Payum\Action\ConvertPaymentAction;
+use KHTools\VPos\Payum\Action\RefundAction;
+use KHTools\VPos\Payum\Action\StatusAction;
+use KHTools\VPos\Payum\Action\SyncAction;
+use KHTools\VPos\Payum\KHVPosGatewayFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class PayumGatewayPassTest extends TestCase
+{
+    public function testIsNoopWhenPayumServiceAbsent(): void
+    {
+        $container = new ContainerBuilder();
+        // No 'payum' service registered
+        $pass = new PayumGatewayPass();
+        $pass->process($container);
+        // Should not throw and should not add any definitions
+        $this->assertFalse($container->hasDefinition('khvpos.payum.gateway_factory'));
+    }
+
+    public function testRegistersGatewayFactoryAndActionsWhenPayumPresent(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('payum', new Definition(\stdClass::class));
+        $container->setDefinition('khvpos.vpos_client', new Definition(\stdClass::class));
+        $container->setParameter('khvpos.client_provider.config', [
+            'merchants' => [['merchant_id' => 'M123']],
+        ]);
+
+        $pass = new PayumGatewayPass();
+        $pass->process($container);
+
+        $this->assertTrue($container->hasDefinition('khvpos.payum.gateway_factory'));
+
+        $factoryDef = $container->getDefinition('khvpos.payum.gateway_factory');
+        $tags = $factoryDef->getTags();
+        $this->assertArrayHasKey('payum.gateway_factory', $tags);
+        $this->assertSame('khvpos', $tags['payum.gateway_factory'][0]['factory_name']);
+
+        // Verify action services are registered
+        foreach ([
+            'khvpos.payum.action.convert'   => ConvertPaymentAction::class,
+            'khvpos.payum.action.capture'    => CaptureAction::class,
+            'khvpos.payum.action.authorize'  => AuthorizeAction::class,
+            'khvpos.payum.action.status'     => StatusAction::class,
+            'khvpos.payum.action.refund'     => RefundAction::class,
+            'khvpos.payum.action.cancel'     => CancelAction::class,
+            'khvpos.payum.action.sync'       => SyncAction::class,
+        ] as $serviceId => $class) {
+            $this->assertTrue($container->hasDefinition($serviceId), "Missing service: $serviceId");
+            $def = $container->getDefinition($serviceId);
+            $this->assertSame($class, $def->getClass());
+            $actionTags = $def->getTags();
+            $this->assertArrayHasKey('payum.action', $actionTags);
+            $this->assertSame('khvpos', $actionTags['payum.action'][0]['factory'] ?? null);
+        }
+    }
+}

--- a/tests/Tests/Payum/Action/AuthorizeActionTest.php
+++ b/tests/Tests/Payum/Action/AuthorizeActionTest.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\Tests\Payum\Action;
+
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Payum\Action\AuthorizeAction;
+use KHTools\VPos\Payum\Constants;
+use KHTools\VPos\Requests\PaymentInitRequest;
+use KHTools\VPos\Requests\PaymentProcessRequest;
+use KHTools\VPos\Responses\PaymentInitResponse;
+use KHTools\VPos\VPosClient;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Request\Authorize;
+use PHPUnit\Framework\TestCase;
+
+class AuthorizeActionTest extends TestCase
+{
+    private function merchant(): Merchant
+    {
+        $m = new Merchant();
+        $m->merchantId = 'M123';
+        return $m;
+    }
+
+    public function testSupportsAuthorizeWithArrayAccessModel(): void
+    {
+        $client = $this->createMock(VPosClient::class);
+        $action = new AuthorizeAction($client, $this->merchant());
+        $this->assertTrue($action->supports(new Authorize(new ArrayObject())));
+    }
+
+    public function testCallsPaymentInitAndStoresUrlWithoutRedirecting(): void
+    {
+        $initResponse = new PaymentInitResponse();
+        $initResponse->setPaymentId('pay-auth');
+        $initResponse->setPaymentStatus(Constants::STATUS_PENDING);
+        $initResponse->setResultCode(Constants::RESULT_OK);
+        $initResponse->setResultMessage('OK');
+
+        $client = $this->createMock(VPosClient::class);
+        $client->expects($this->once())
+            ->method('send')
+            ->with($this->isInstanceOf(PaymentInitRequest::class))
+            ->willReturn($initResponse);
+        $client->expects($this->once())
+            ->method('getPaymentUrlWithPaymentProcessRequest')
+            ->with($this->isInstanceOf(PaymentProcessRequest::class))
+            ->willReturn('https://api.khpos.hu/pay-auth-url');
+
+        $model = new ArrayObject([
+            'order_number'  => 'ORDER-3',
+            'total_amount'  => 2000,
+            'currency'      => 'HUF',
+            'return_url'    => 'https://example.com/return',
+            'return_method' => 'POST',
+        ]);
+        $action = new AuthorizeAction($client, $this->merchant());
+        $action->execute(new Authorize($model)); // must NOT throw HttpRedirect
+
+        $this->assertSame('pay-auth', $model['payId']);
+        $this->assertSame('https://api.khpos.hu/pay-auth-url', $model['authorization_url']);
+        $this->assertSame(Constants::STATUS_PENDING, $model['paymentStatus']);
+        $this->assertSame(Constants::RESULT_OK,      $model['resultCode']);
+        $this->assertSame('OK',                      $model['resultMessage']);
+    }
+}

--- a/tests/Tests/Payum/Action/CancelActionTest.php
+++ b/tests/Tests/Payum/Action/CancelActionTest.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\Tests\Payum\Action;
+
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Payum\Action\CancelAction;
+use KHTools\VPos\Payum\Constants;
+use KHTools\VPos\Requests\PaymentCloseRequest;
+use KHTools\VPos\Requests\PaymentReverseRequest;
+use KHTools\VPos\Responses\PaymentCloseResponse;
+use KHTools\VPos\Responses\PaymentReverseResponse;
+use KHTools\VPos\VPosClient;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Request\Cancel;
+use PHPUnit\Framework\TestCase;
+
+class CancelActionTest extends TestCase
+{
+    private function merchant(): Merchant
+    {
+        $m = new Merchant();
+        $m->merchantId = 'M123';
+        return $m;
+    }
+
+    public function testSupportsCancelWithArrayAccessModel(): void
+    {
+        $client = $this->createMock(VPosClient::class);
+        $action = new CancelAction($client, $this->merchant());
+        $this->assertTrue($action->supports(new Cancel(new ArrayObject())));
+    }
+
+    public function testCallsReverseForStatusPending(): void
+    {
+        $reverseResponse = new PaymentReverseResponse();
+        $reverseResponse->setResultCode(Constants::RESULT_OK);
+        $reverseResponse->setResultMessage('OK');
+
+        $client = $this->createMock(VPosClient::class);
+        $client->expects($this->once())
+            ->method('send')
+            ->with($this->isInstanceOf(PaymentReverseRequest::class))
+            ->willReturn($reverseResponse);
+
+        $model = new ArrayObject(['payId' => 'pay-1', 'paymentStatus' => Constants::STATUS_PENDING]);
+        (new CancelAction($client, $this->merchant()))->execute(new Cancel($model));
+        $this->assertSame(Constants::RESULT_OK, $model['resultCode']);
+    }
+
+    public function testCallsReverseForStatusProcessing(): void
+    {
+        $reverseResponse = new PaymentReverseResponse();
+        $reverseResponse->setResultCode(Constants::RESULT_OK);
+        $reverseResponse->setResultMessage('OK');
+
+        $client = $this->createMock(VPosClient::class);
+        $client->expects($this->once())
+            ->method('send')
+            ->with($this->isInstanceOf(PaymentReverseRequest::class))
+            ->willReturn($reverseResponse);
+
+        $model = new ArrayObject(['payId' => 'pay-2', 'paymentStatus' => Constants::STATUS_PROCESSING]);
+        (new CancelAction($client, $this->merchant()))->execute(new Cancel($model));
+        $this->assertSame(Constants::RESULT_OK, $model['resultCode']);
+    }
+
+    public function testCallsCloseForStatusAuthorized(): void
+    {
+        $closeResponse = new PaymentCloseResponse();
+        $closeResponse->setResultCode(Constants::RESULT_OK);
+        $closeResponse->setResultMessage('OK');
+
+        $client = $this->createMock(VPosClient::class);
+        $client->expects($this->once())
+            ->method('send')
+            ->with($this->isInstanceOf(PaymentCloseRequest::class))
+            ->willReturn($closeResponse);
+
+        $model = new ArrayObject(['payId' => 'pay-3', 'paymentStatus' => Constants::STATUS_AUTHORIZED]);
+        (new CancelAction($client, $this->merchant()))->execute(new Cancel($model));
+        $this->assertSame(Constants::RESULT_OK, $model['resultCode']);
+    }
+
+    public function testCallsCloseForStatusCancelled(): void
+    {
+        $closeResponse = new PaymentCloseResponse();
+        $closeResponse->setResultCode(Constants::RESULT_OK);
+        $closeResponse->setResultMessage('OK');
+
+        $client = $this->createMock(VPosClient::class);
+        $client->expects($this->once())
+            ->method('send')
+            ->with($this->isInstanceOf(PaymentCloseRequest::class))
+            ->willReturn($closeResponse);
+
+        $model = new ArrayObject(['payId' => 'pay-5', 'paymentStatus' => Constants::STATUS_CANCELLED]);
+        (new CancelAction($client, $this->merchant()))->execute(new Cancel($model));
+        $this->assertSame(Constants::RESULT_OK, $model['resultCode']);
+    }
+
+    public function testThrowsLogicExceptionForAlreadyCapturedPayment(): void
+    {
+        $client = $this->createMock(VPosClient::class);
+        $client->expects($this->never())->method('send');
+
+        $model = new ArrayObject(['payId' => 'pay-4', 'paymentStatus' => Constants::STATUS_CONFIRMED]);
+        $this->expectException(\LogicException::class);
+        (new CancelAction($client, $this->merchant()))->execute(new Cancel($model));
+    }
+}

--- a/tests/Tests/Payum/Action/CaptureActionTest.php
+++ b/tests/Tests/Payum/Action/CaptureActionTest.php
@@ -1,0 +1,123 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\Tests\Payum\Action;
+
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Payum\Action\CaptureAction;
+use KHTools\VPos\Payum\Constants;
+use KHTools\VPos\Requests\PaymentInitRequest;
+use KHTools\VPos\Requests\PaymentProcessRequest;
+use KHTools\VPos\Requests\PaymentStatusRequest;
+use KHTools\VPos\Responses\PaymentInitResponse;
+use KHTools\VPos\Responses\PaymentStatusResponse;
+use KHTools\VPos\VPosClient;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Reply\HttpRedirect;
+use Payum\Core\Request\Capture;
+use PHPUnit\Framework\TestCase;
+
+class CaptureActionTest extends TestCase
+{
+    private function merchant(): Merchant
+    {
+        $m = new Merchant();
+        $m->merchantId = 'M123';
+        return $m;
+    }
+
+    public function testSupportsCaptureWithArrayAccessModel(): void
+    {
+        $client = $this->createMock(VPosClient::class);
+        $action = new CaptureAction($client, $this->merchant());
+        $this->assertTrue($action->supports(new Capture(new ArrayObject())));
+    }
+
+    public function testFirstPassCallsPaymentInitAndThrowsHttpRedirect(): void
+    {
+        $initResponse = new PaymentInitResponse();
+        $initResponse->setPaymentId('pay-new');
+        $initResponse->setPaymentStatus(Constants::STATUS_PENDING);
+        $initResponse->setResultCode(Constants::RESULT_OK);
+        $initResponse->setResultMessage('OK');
+
+        $client = $this->createMock(VPosClient::class);
+        $client->expects($this->once())
+            ->method('send')
+            ->with($this->isInstanceOf(PaymentInitRequest::class))
+            ->willReturn($initResponse);
+        $client->expects($this->once())
+            ->method('getPaymentUrlWithPaymentProcessRequest')
+            ->with($this->isInstanceOf(PaymentProcessRequest::class))
+            ->willReturn('https://api.khpos.hu/api/v1.0/payment/process/M123/pay-new/...');
+
+        $model = new ArrayObject([
+            'order_number' => 'ORDER-1',
+            'total_amount' => 10000,
+            'currency'     => 'HUF',
+            'return_url'   => 'https://example.com/return',
+            'return_method' => 'POST',
+        ]);
+        $capture = new Capture($model);
+        $action = new CaptureAction($client, $this->merchant());
+
+        $this->expectException(HttpRedirect::class);
+        $action->execute($capture);
+    }
+
+    public function testFirstPassStoresPayIdBeforeRedirect(): void
+    {
+        $initResponse = new PaymentInitResponse();
+        $initResponse->setPaymentId('pay-stored');
+        $initResponse->setPaymentStatus(Constants::STATUS_PENDING);
+        $initResponse->setResultCode(Constants::RESULT_OK);
+        $initResponse->setResultMessage('OK');
+
+        $client = $this->createMock(VPosClient::class);
+        $client->method('send')->willReturn($initResponse);
+        $client->method('getPaymentUrlWithPaymentProcessRequest')->willReturn('https://example.com/pay');
+
+        $model = new ArrayObject([
+            'order_number' => 'ORDER-2',
+            'total_amount' => 5000,
+            'currency'     => 'HUF',
+            'return_url'   => 'https://example.com/return',
+            'return_method' => 'POST',
+        ]);
+        $action = new CaptureAction($client, $this->merchant());
+
+        try {
+            $action->execute(new Capture($model));
+        } catch (HttpRedirect) {
+            // Expected
+        }
+
+        $this->assertSame('pay-stored', $model['payId']);
+        $this->assertSame(Constants::STATUS_PENDING, $model['paymentStatus']);
+        $this->assertSame(Constants::RESULT_OK, $model['resultCode']);
+        $this->assertSame('OK', $model['resultMessage']);
+    }
+
+    public function testSecondPassCallsPaymentStatusAndUpdatesModel(): void
+    {
+        $statusResponse = new PaymentStatusResponse();
+        $statusResponse->setPaymentId('pay-exist');
+        $statusResponse->setResultCode(Constants::RESULT_OK);
+        $statusResponse->setResultMessage('OK');
+        $statusResponse->setPaymentStatus(Constants::STATUS_CONFIRMED);
+
+        $client = $this->createMock(VPosClient::class);
+        $client->expects($this->once())
+            ->method('send')
+            ->with($this->callback(fn ($r) => $r instanceof PaymentStatusRequest && $r->getPaymentId() === 'pay-exist'))
+            ->willReturn($statusResponse);
+        $client->expects($this->never())->method('getPaymentUrlWithPaymentProcessRequest');
+
+        $model = new ArrayObject(['payId' => 'pay-exist']);
+        $action = new CaptureAction($client, $this->merchant());
+        $action->execute(new Capture($model));
+
+        $this->assertSame(Constants::RESULT_OK, $model['resultCode']);
+        $this->assertSame(Constants::STATUS_CONFIRMED, $model['paymentStatus']);
+        $this->assertSame('OK', $model['resultMessage']);
+    }
+}

--- a/tests/Tests/Payum/Action/ConvertPaymentActionTest.php
+++ b/tests/Tests/Payum/Action/ConvertPaymentActionTest.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\Tests\Payum\Action;
+
+use KHTools\VPos\Payum\Action\ConvertPaymentAction;
+use Payum\Core\Model\Payment;
+use Payum\Core\Request\Convert;
+use PHPUnit\Framework\TestCase;
+
+class ConvertPaymentActionTest extends TestCase
+{
+    private ConvertPaymentAction $action;
+
+    protected function setUp(): void
+    {
+        $this->action = new ConvertPaymentAction();
+    }
+
+    public function testSupportConvertWithPaymentModel(): void
+    {
+        $convert = new Convert(new Payment(), 'array');
+        $this->assertTrue($this->action->supports($convert));
+    }
+
+    public function testDoesNotSupportConvertWithNonPaymentSource(): void
+    {
+        $convert = new Convert(new \stdClass(), 'array');
+        $this->assertFalse($this->action->supports($convert));
+    }
+
+    public function testDoesNotSupportConvertToNonArray(): void
+    {
+        $convert = new Convert(new Payment(), 'json');
+        $this->assertFalse($this->action->supports($convert));
+    }
+
+    public function testMapsPaymentFieldsToDetailsArray(): void
+    {
+        $payment = new Payment();
+        $payment->setNumber('ORDER-001');
+        $payment->setTotalAmount(10000); // 100.00 HUF in fillér
+        $payment->setCurrencyCode('HUF');
+        $payment->setDetails([
+            'return_url'    => 'https://example.com/return',
+            'return_method' => 'POST',
+            'merchant_id'   => 'M123',
+        ]);
+
+        $convert = new Convert($payment, 'array');
+        $this->action->execute($convert);
+
+        $result = $convert->getResult();
+        $this->assertSame('ORDER-001', $result['order_number']);
+        $this->assertSame(10000, $result['total_amount']);
+        $this->assertSame('HUF', $result['currency']);
+        $this->assertSame('https://example.com/return', $result['return_url']);
+        $this->assertSame('POST', $result['return_method']);
+        $this->assertSame('M123', $result['merchant_id']);
+    }
+
+    public function testDefaultsReturnMethodToPost(): void
+    {
+        $payment = new Payment();
+        $payment->setNumber('ORDER-002');
+        $payment->setTotalAmount(500);
+        $payment->setCurrencyCode('HUF');
+        $payment->setDetails(['return_url' => 'https://example.com/return']);
+
+        $convert = new Convert($payment, 'array');
+        $this->action->execute($convert);
+
+        $this->assertSame('POST', $convert->getResult()['return_method']);
+    }
+}

--- a/tests/Tests/Payum/Action/RefundActionTest.php
+++ b/tests/Tests/Payum/Action/RefundActionTest.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\Tests\Payum\Action;
+
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Payum\Action\RefundAction;
+use KHTools\VPos\Payum\Constants;
+use KHTools\VPos\Requests\PaymentRefundRequest;
+use KHTools\VPos\Responses\PaymentRefundResponse;
+use KHTools\VPos\VPosClient;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Request\Refund;
+use PHPUnit\Framework\TestCase;
+
+class RefundActionTest extends TestCase
+{
+    private function merchant(): Merchant
+    {
+        $m = new Merchant();
+        $m->merchantId = 'M123';
+        return $m;
+    }
+
+    public function testSupportsRefundWithArrayAccessModel(): void
+    {
+        $client = $this->createMock(VPosClient::class);
+        $action = new RefundAction($client, $this->merchant());
+        $this->assertTrue($action->supports(new Refund(new ArrayObject())));
+    }
+
+    public function testCallsPaymentRefundRequestAndUpdatesModel(): void
+    {
+        $refundResponse = new PaymentRefundResponse();
+        $refundResponse->setResultCode(Constants::RESULT_OK);
+        $refundResponse->setResultMessage('OK');
+
+        $client = $this->createMock(VPosClient::class);
+        $client->expects($this->once())
+            ->method('send')
+            ->with($this->callback(fn ($r) =>
+                $r instanceof PaymentRefundRequest
+                && $r->getPaymentId() === 'pay-refund'
+            ))
+            ->willReturn($refundResponse);
+
+        $model = new ArrayObject(['payId' => 'pay-refund']);
+        $action = new RefundAction($client, $this->merchant());
+        $action->execute(new Refund($model));
+
+        $this->assertSame(Constants::RESULT_OK, $model['resultCode']);
+        $this->assertSame('OK', $model['resultMessage']);
+    }
+
+    public function testPassesRefundAmountWhenPresent(): void
+    {
+        $refundResponse = new PaymentRefundResponse();
+        $refundResponse->setResultCode(Constants::RESULT_OK);
+        $refundResponse->setResultMessage('OK');
+
+        $capturedRequest = null;
+        $client = $this->createMock(VPosClient::class);
+        $client->method('send')
+            ->willReturnCallback(function ($request) use (&$capturedRequest, $refundResponse) {
+                $capturedRequest = $request;
+                return $refundResponse;
+            });
+
+        $model = new ArrayObject(['payId' => 'pay-refund', 'refund_amount' => 5000]);
+        $action = new RefundAction($client, $this->merchant());
+        $action->execute(new Refund($model));
+
+        $this->assertInstanceOf(PaymentRefundRequest::class, $capturedRequest);
+        // 5000 fillér = 50.00 HUF; getRawAmount() should be 5000
+        $this->assertSame(5000, $capturedRequest->getRawAmount());
+    }
+}

--- a/tests/Tests/Payum/Action/StatusActionTest.php
+++ b/tests/Tests/Payum/Action/StatusActionTest.php
@@ -1,0 +1,158 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\Tests\Payum\Action;
+
+use KHTools\VPos\Payum\Action\StatusAction;
+use KHTools\VPos\Payum\Constants;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Request\GetHumanStatus;
+use PHPUnit\Framework\TestCase;
+
+class StatusActionTest extends TestCase
+{
+    private StatusAction $action;
+
+    protected function setUp(): void
+    {
+        $this->action = new StatusAction();
+    }
+
+    public function testSupportsGetHumanStatusWithArrayAccessModel(): void
+    {
+        $status = new GetHumanStatus(new ArrayObject());
+        $this->assertTrue($this->action->supports($status));
+    }
+
+    public function testDoesNotSupportOtherRequests(): void
+    {
+        $this->assertFalse($this->action->supports(new \stdClass()));
+    }
+
+    public function testMarksNewWhenNoPayIdInModel(): void
+    {
+        $model = new ArrayObject([]);
+        $status = new GetHumanStatus($model);
+        $this->action->execute($status);
+        $this->assertTrue($status->isNew());
+    }
+
+    public function testMarksCapturedForResultCode0AndPaymentStatus4(): void
+    {
+        $model = new ArrayObject([
+            'payId'         => 'pay-123',
+            'resultCode'    => Constants::RESULT_OK,
+            'paymentStatus' => Constants::STATUS_CONFIRMED,
+        ]);
+        $status = new GetHumanStatus($model);
+        $this->action->execute($status);
+        $this->assertTrue($status->isCaptured());
+    }
+
+    public function testMarksPendingForPaymentStatus1(): void
+    {
+        $model = new ArrayObject([
+            'payId'         => 'pay-123',
+            'resultCode'    => Constants::RESULT_OK,
+            'paymentStatus' => Constants::STATUS_PENDING,
+        ]);
+        $status = new GetHumanStatus($model);
+        $this->action->execute($status);
+        $this->assertTrue($status->isPending());
+    }
+
+    public function testMarksPendingForPaymentStatus2(): void
+    {
+        $model = new ArrayObject([
+            'payId'         => 'pay-123',
+            'resultCode'    => Constants::RESULT_OK,
+            'paymentStatus' => Constants::STATUS_PROCESSING,
+        ]);
+        $status = new GetHumanStatus($model);
+        $this->action->execute($status);
+        $this->assertTrue($status->isPending());
+    }
+
+    public function testMarksPendingFor3DsInProgress(): void
+    {
+        $model = new ArrayObject([
+            'payId'         => 'pay-123',
+            'resultCode'    => Constants::RESULT_3DS_IN_PROGRESS,
+            'paymentStatus' => Constants::STATUS_PENDING,
+        ]);
+        $status = new GetHumanStatus($model);
+        $this->action->execute($status);
+        $this->assertTrue($status->isPending());
+    }
+
+    public function testMarksAuthorizedForPaymentStatus5(): void
+    {
+        $model = new ArrayObject([
+            'payId'         => 'pay-123',
+            'resultCode'    => Constants::RESULT_OK,
+            'paymentStatus' => Constants::STATUS_AUTHORIZED,
+        ]);
+        $status = new GetHumanStatus($model);
+        $this->action->execute($status);
+        $this->assertTrue($status->isAuthorized());
+    }
+
+    public function testMarksCanceledForPaymentStatus3(): void
+    {
+        $model = new ArrayObject([
+            'payId'         => 'pay-123',
+            'resultCode'    => Constants::RESULT_OK,
+            'paymentStatus' => Constants::STATUS_CANCELLED,
+        ]);
+        $status = new GetHumanStatus($model);
+        $this->action->execute($status);
+        $this->assertTrue($status->isCanceled());
+    }
+
+    public function testMarksCanceledForPaymentStatus7(): void
+    {
+        $model = new ArrayObject([
+            'payId'         => 'pay-123',
+            'resultCode'    => Constants::RESULT_OK,
+            'paymentStatus' => Constants::STATUS_REVERSED,
+        ]);
+        $status = new GetHumanStatus($model);
+        $this->action->execute($status);
+        $this->assertTrue($status->isCanceled());
+    }
+
+    public function testMarksCanceledForPaymentStatus8(): void
+    {
+        $model = new ArrayObject([
+            'payId'         => 'pay-123',
+            'resultCode'    => Constants::RESULT_OK,
+            'paymentStatus' => Constants::STATUS_CLOSED,
+        ]);
+        $status = new GetHumanStatus($model);
+        $this->action->execute($status);
+        $this->assertTrue($status->isCanceled());
+    }
+
+    public function testMarksFailedForNonZeroResultCode(): void
+    {
+        $model = new ArrayObject([
+            'payId'         => 'pay-123',
+            'resultCode'    => 400,
+            'paymentStatus' => Constants::STATUS_REJECTED,
+        ]);
+        $status = new GetHumanStatus($model);
+        $this->action->execute($status);
+        $this->assertTrue($status->isFailed());
+    }
+
+    public function testMarksUnknownForUnrecognizedPaymentStatus(): void
+    {
+        $model = new ArrayObject([
+            'payId'         => 'pay-123',
+            'resultCode'    => Constants::RESULT_OK,
+            'paymentStatus' => Constants::STATUS_REJECTED, // 6 — no mapping in StatusAction
+        ]);
+        $status = new GetHumanStatus($model);
+        $this->action->execute($status);
+        $this->assertTrue($status->isUnknown());
+    }
+}

--- a/tests/Tests/Payum/Action/SyncActionTest.php
+++ b/tests/Tests/Payum/Action/SyncActionTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\Tests\Payum\Action;
+
+use KHTools\VPos\Models\Merchant;
+use KHTools\VPos\Payum\Action\SyncAction;
+use KHTools\VPos\Payum\Constants;
+use KHTools\VPos\Requests\PaymentStatusRequest;
+use KHTools\VPos\Responses\PaymentStatusResponse;
+use KHTools\VPos\VPosClient;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Request\Sync;
+use PHPUnit\Framework\TestCase;
+
+class SyncActionTest extends TestCase
+{
+    private function merchant(): Merchant
+    {
+        $m = new Merchant();
+        $m->merchantId = 'M123';
+        return $m;
+    }
+
+    public function testSupportsSyncWithArrayAccessModel(): void
+    {
+        $client = $this->createMock(VPosClient::class);
+        $action = new SyncAction($client, $this->merchant());
+        $this->assertTrue($action->supports(new Sync(new ArrayObject())));
+    }
+
+    public function testDoesNothingWhenNoPayIdInModel(): void
+    {
+        $client = $this->createMock(VPosClient::class);
+        $client->expects($this->never())->method('send');
+
+        $action = new SyncAction($client, $this->merchant());
+        $model = new ArrayObject([]);
+        $action->execute(new Sync($model));
+    }
+
+    public function testFetchesStatusAndUpdatesModel(): void
+    {
+        $statusResponse = new PaymentStatusResponse();
+        $statusResponse->setPaymentId('pay-abc');
+        $statusResponse->setResultCode(Constants::RESULT_OK);
+        $statusResponse->setResultMessage('OK');
+        $statusResponse->setPaymentStatus(Constants::STATUS_CONFIRMED);
+
+        $client = $this->createMock(VPosClient::class);
+        $client->expects($this->once())
+            ->method('send')
+            ->with($this->callback(fn ($r) => $r instanceof PaymentStatusRequest && $r->getPaymentId() === 'pay-abc'))
+            ->willReturn($statusResponse);
+
+        $action = new SyncAction($client, $this->merchant());
+        $model = new ArrayObject(['payId' => 'pay-abc']);
+        $action->execute(new Sync($model));
+
+        $this->assertSame(Constants::RESULT_OK, $model['resultCode']);
+        $this->assertSame(Constants::STATUS_CONFIRMED, $model['paymentStatus']);
+        $this->assertSame('OK', $model['resultMessage']);
+    }
+}

--- a/tests/Tests/Payum/ConstantsTest.php
+++ b/tests/Tests/Payum/ConstantsTest.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\Tests\Payum;
+
+use KHTools\VPos\Payum\Constants;
+use PHPUnit\Framework\TestCase;
+
+class ConstantsTest extends TestCase
+{
+    public function testPaymentStatusConstantsAreIntegers(): void
+    {
+        $this->assertSame(1, Constants::STATUS_PENDING);
+        $this->assertSame(2, Constants::STATUS_PROCESSING);
+        $this->assertSame(3, Constants::STATUS_CANCELLED);
+        $this->assertSame(4, Constants::STATUS_CONFIRMED);
+        $this->assertSame(5, Constants::STATUS_AUTHORIZED);
+        $this->assertSame(6, Constants::STATUS_REJECTED);
+        $this->assertSame(7, Constants::STATUS_REVERSED);
+        $this->assertSame(8, Constants::STATUS_CLOSED);
+        $this->assertSame(0, Constants::RESULT_OK);
+        $this->assertSame(150, Constants::RESULT_3DS_IN_PROGRESS);
+    }
+}

--- a/tests/Tests/Payum/KHVPosGatewayFactoryTest.php
+++ b/tests/Tests/Payum/KHVPosGatewayFactoryTest.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace KHTools\Tests\Payum;
+
+use KHTools\VPos\Payum\KHVPosGatewayFactory;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\GatewayInterface;
+use Payum\Core\Request\GetHumanStatus;
+use PHPUnit\Framework\TestCase;
+
+class KHVPosGatewayFactoryTest extends TestCase
+{
+    private const FIXTURES = __DIR__ . '/../Fixtures';
+
+    public function testCreateReturnsGatewayInterface(): void
+    {
+        $factory = new KHVPosGatewayFactory();
+        $gateway = $factory->create([
+            'merchant_id'          => 'M123',
+            'private_key_path'     => self::FIXTURES . '/test1_private_key.pem',
+            'mips_public_key_path' => self::FIXTURES . '/test1_public_key.pem',
+        ]);
+        $this->assertInstanceOf(GatewayInterface::class, $gateway);
+
+        // Verify StatusAction is wired (no client dependency — safe to invoke)
+        $model = new ArrayObject([]);
+        $status = new GetHumanStatus($model);
+        $gateway->execute($status);
+        $this->assertTrue($status->isNew());
+    }
+
+    public function testCreateThrowsWhenMerchantIdMissing(): void
+    {
+        $factory = new KHVPosGatewayFactory();
+        $this->expectException(\InvalidArgumentException::class);
+        $factory->create(['private_key_path' => '/tmp/key.pem']);
+    }
+
+    public function testCreateThrowsWhenPrivateKeyPathMissing(): void
+    {
+        $factory = new KHVPosGatewayFactory();
+        $this->expectException(\InvalidArgumentException::class);
+        $factory->create(['merchant_id' => 'M123']);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an optional Payum integration layer in `src/Payum/` — works standalone with `payum/core ^1.7` and in any PHP environment via `KHVPosGatewayFactory`
- Implements all 7 Payum actions: `ConvertPaymentAction`, `CaptureAction` (two-pass redirect flow), `AuthorizeAction`, `StatusAction`, `SyncAction`, `RefundAction`, `CancelAction`
- Adds `PayumGatewayPass` CompilerPass that auto-wires the gateway factory and all actions in Symfony when `payum/payum-bundle` is present — no extra YAML config needed beyond the existing `khvpos:` block

## Test Plan

- [ ] 260 tests pass (`phpunit-11 --colors=always`), up from 218 — 42 new Payum tests
- [ ] PHPStan level 8 clean (`composer phpstan`) — 0 errors
- [ ] Standalone use: `KHVPosGatewayFactory::create([merchant_id, private_key_path, ...])` returns a wired `GatewayInterface`
- [ ] Symfony use: with `payum/payum-bundle` installed, `$payum->getGateway('khvpos')` works automatically
- [ ] `PayumGatewayPass` is a no-op when `payum` service is absent (bundle safe to install without Payum)

## Notes

- **Status mapping**: `StatusAction` maps K&H `paymentStatus` integers to Payum human statuses per the implementation plan. The design spec table had a minor inconsistency for statuses 3/5/6 — please verify the final mapping against the K&H API docs before release.
- `payum/core` and `payum/payum-bundle` are `require-dev` only; runtime dependency is `suggest`-only as expected for a library.
- Multi-merchant Payum support is not yet implemented; `PayumGatewayPass` wires the first configured merchant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)